### PR TITLE
Add `include_asm` and `include_hex`

### DIFF
--- a/etk-asm/src/ast.rs
+++ b/etk-asm/src/ast.rs
@@ -7,6 +7,7 @@ pub enum Node {
     Raw(Vec<u8>),
     Include(PathBuf),
     IncludeAsm(PathBuf),
+    IncludeHex(PathBuf),
 }
 
 impl Node {

--- a/etk-asm/src/ast.rs
+++ b/etk-asm/src/ast.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Node {
     Op(Op),
+    Raw(Vec<u8>),
     Include(PathBuf),
     IncludeAsm(PathBuf),
 }

--- a/etk-asm/src/ast.rs
+++ b/etk-asm/src/ast.rs
@@ -1,0 +1,24 @@
+use crate::ops::Op;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Node {
+    Op(Op),
+    Include(PathBuf),
+    IncludeAsm(PathBuf),
+}
+
+impl Node {
+    pub(crate) fn assemble(&self, buf: &mut Vec<u8>) {
+        match self {
+            Self::Op(op) => op.assemble(buf),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl From<Op> for Node {
+    fn from(op: Op) -> Self {
+        Node::Op(op)
+    }
+}

--- a/etk-asm/src/lib.rs
+++ b/etk-asm/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod asm;
+pub mod ast;
 pub mod disasm;
 pub mod ops;
 mod parse;

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -40,6 +40,7 @@ jumpdest = { "jumpdest" ~ label }
 
 include = { "include(\"" ~ path ~ "\")" }
 include_asm = { "include_asm(\"" ~ path ~ "\")" }
+include_hex = { "include_hex(\"" ~ path ~ "\")" }
 path = @{ (ASCII_ALPHANUMERIC | "/" | ".")+ }
 
 WHITESPACE = _{ " " | "\t" }

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -2,7 +2,7 @@ program = _{ SOI ~ "\n"* ~ (stmt ~ "\n"+)* ~ stmt? ~ EOI }
 
 stmt = _{ expr }
 
-expr = _{ jumpdest | op | push | include }
+expr = _{ jumpdest | op | push | include | include_asm }
 
 op = @{ 
 	"origin" | "stop" | "mul" | "sub" | "div" | "sdiv" | "mod" | "smod" |
@@ -39,6 +39,7 @@ label = @{ "." ~ (ASCII_ALPHA_LOWER ~ "_"*)+ }
 jumpdest = { "jumpdest" ~ label }
 
 include = { "include(\"" ~ path ~ "\")" }
+include_asm = { "include_asm(\"" ~ path ~ "\")" }
 path = @{ (ASCII_ALPHANUMERIC | "/" | ".")+ }
 
 WHITESPACE = _{ " " | "\t" }


### PR DESCRIPTION
I've really go back and forth a lot on how to do this. At this point, I sort of just wanted to get it done. Not very happy with the code, but it does work. Let me know what you think. I'm sort of thinking I'll try to also hack out macros soon and then freeze features for a bit and really clean up the assembler.

Btw: better name recommendations that "node"?