### PR TITLE
Couple small grammar changes

### DIFF
--- a/etk-asm/src/parse/args.rs
+++ b/etk-asm/src/parse/args.rs
@@ -1,0 +1,71 @@
+use pest::iterators::{Pair, Pairs};
+
+use std::path::PathBuf;
+
+use super::{ParseError, Rule};
+
+pub trait FromPair: Sized {
+    fn from_pair(pair: Pair<Rule>) -> Result<Self, ParseError>;
+}
+
+impl FromPair for PathBuf {
+    fn from_pair(pair: Pair<Rule>) -> Result<Self, ParseError> {
+        if pair.as_rule() == Rule::string {
+            let txt = pair.as_str();
+            if txt.contains('\\') {
+                // TODO
+                panic!("backslashes in paths aren't implemented yet.");
+            }
+            Ok(txt[1..txt.len() - 1].into())
+        } else {
+            Err(ParseError::ArgumentType)
+        }
+    }
+}
+
+pub trait Signature {
+    type Output;
+    fn parse_arguments(pairs: Pairs<Rule>) -> Result<Self::Output, ParseError>;
+}
+
+fn arg<T>(pairs: &mut Pairs<Rule>, expected: usize, got: &mut usize) -> Result<T, ParseError>
+where
+    T: FromPair,
+{
+    let pair = pairs.next().ok_or(ParseError::MissingArgument {
+        got: *got,
+        expected,
+    })?;
+    *got += 1;
+    T::from_pair(pair)
+}
+
+impl Signature for () {
+    type Output = Self;
+
+    fn parse_arguments(mut pairs: Pairs<Rule>) -> Result<Self, ParseError> {
+        match pairs.next() {
+            Some(_) => Err(ParseError::ExtraArgument { expected: 0 }),
+            None => Ok(()),
+        }
+    }
+}
+
+impl<T> Signature for (T,)
+where
+    T: FromPair,
+{
+    type Output = Self;
+
+    fn parse_arguments(mut pairs: Pairs<Rule>) -> Result<Self, ParseError> {
+        let expected = 1;
+        let mut got = 0;
+
+        let result = (arg::<T>(&mut pairs, expected, &mut got)?,);
+
+        match pairs.next() {
+            Some(_) => Err(ParseError::ExtraArgument { expected }),
+            None => Ok(result),
+        }
+    }
+}

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -19,7 +19,7 @@ op = @{
 	"staticcall" | "revert" | "selfdestruct"
 }
 
-push = { "push" ~  word_size ~ (hex | octal | binary | decimal | selector | label) }
+push = ${ "push" ~  word_size ~ WHITESPACE ~ (hex | octal | binary | decimal | selector | label) }
 swap = { "swap" ~ half_word_size }
 dup  = { "dup" ~ half_word_size }
 log = { "log" ~ '0'..'4' }

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -2,7 +2,7 @@ program = _{ SOI ~ "\n"* ~ (stmt ~ "\n"+)* ~ stmt? ~ EOI }
 
 stmt = _{ expr }
 
-expr = _{ jumpdest | op | push | include | include_asm }
+expr = _{ jumpdest | op | push | inst_macro }
 
 op = @{
 	"origin" | "stop" | "mul" | "sub" | "div" | "sdiv" | "mod" | "smod" |
@@ -47,9 +47,11 @@ arguments_list = _{ ( argument ~ "," )* ~ argument? }
 argument = _{ string | numeric_argument }
 numeric_argument = _{ number | label | selector }
 
-include = { "include" ~ arguments }
-include_asm = { "include_asm" ~ arguments }
-include_hex = { "include_hex" ~ arguments }
+inst_macro = ${ "%" ~ ( include | include_asm | include_hex ) }
+
+include = !{ "include" ~ arguments }
+include_asm = !{ "include_asm" ~ arguments }
+include_hex = !{ "include_hex" ~ arguments }
 
 WHITESPACE = _{ " " | "\t" }
 COMMENT = _{ ";" ~ (!"\n" ~ ANY)* }

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -4,7 +4,7 @@ stmt = _{ expr }
 
 expr = _{ jumpdest | op | push | include | include_asm }
 
-op = @{ 
+op = @{
 	"origin" | "stop" | "mul" | "sub" | "div" | "sdiv" | "mod" | "smod" |
 	"addmod" | "mulmod" | "exp" | "signextend" | "lt" | "gt" | "slt" |
 	"sgt" | "eq" | "iszero" | "and" | "or" | "xor" | "not" | "shl" | "shr" |
@@ -12,17 +12,20 @@ op = @{
 	"callvalue" | "calldataload" | "calldatasize" | "calldatacopy" |
 	"codesize" | "codecopy" | "gasprice" | "extcodesize" | "extcodecopy" |
 	"returndatasize" | "returndatacopy" | "extcodehash" | "blockhash" |
-	"coinbase" | "timestamp" | "number" | "difficulty" | "gaslimit" | 
+	"coinbase" | "timestamp" | "number" | "difficulty" | "gaslimit" |
 	"pop" | "mload" | "mstore" | "mstore8" | "sload" | "sstore" | "jumpi" |
 	"jump" | "pc" | "msize" | "gas" | swap | dup | log |
 	"create" | "call" | "callcode" | "return" | "delegatecall" | "create2" |
 	"staticcall" | "revert" | "selfdestruct"
 }
 
-push = ${ "push" ~  word_size ~ WHITESPACE ~ (hex | octal | binary | decimal | selector | label) }
+push = ${ "push" ~  word_size ~ WHITESPACE ~ numeric_argument }
 swap = { "swap" ~ half_word_size }
 dup  = { "dup" ~ half_word_size }
 log = { "log" ~ '0'..'4' }
+
+string = @{ "\"" ~ string_char* ~ "\"" }
+string_char = _{ "\\\\" | "\\\"" | (!"\\" ~ !"\"" ~ ANY) }
 
 word_size = @{ ('1'..'2' ~ '0'..'9') | ("3" ~ '0'..'2') | '1'..'9' }
 half_word_size = @{ ("1" ~ '0'..'6') | '1'..'9' }
@@ -31,17 +34,22 @@ binary = @{ "0b" ~ ASCII_BIN_DIGIT+ }
 octal = @{ "0o" ~ ASCII_OCT_DIGIT+ }
 decimal = @{ ASCII_DIGIT+ }
 hex = @{ "0x" ~ ASCII_HEX_DIGIT ~ ASCII_HEX_DIGIT+ }
+number = _{ binary | octal | hex | decimal }
 
 selector = { "selector(\"" ~ function_declaration ~ "\")" }
 function_declaration = { ASCII_ALPHANUMERIC+ ~ "(" ~ ASCII_ALPHANUMERIC* ~ ("," ~ ASCII_ALPHANUMERIC+)* ~ ")" }
-	
+
 label = @{ "." ~ (ASCII_ALPHA_LOWER ~ "_"*)+ }
 jumpdest = { "jumpdest" ~ label }
 
-include = { "include(\"" ~ path ~ "\")" }
-include_asm = { "include_asm(\"" ~ path ~ "\")" }
-include_hex = { "include_hex(\"" ~ path ~ "\")" }
-path = @{ (ASCII_ALPHANUMERIC | "/" | ".")+ }
+arguments = _{ "(" ~ arguments_list? ~ ")" }
+arguments_list = _{ ( argument ~ "," )* ~ argument? }
+argument = _{ string | numeric_argument }
+numeric_argument = _{ number | label | selector }
+
+include = { "include" ~ arguments }
+include_asm = { "include_asm" ~ arguments }
+include_hex = { "include_hex" ~ arguments }
 
 WHITESPACE = _{ " " | "\t" }
 COMMENT = _{ ";" ~ (!"\n" ~ ANY)* }


### PR DESCRIPTION
 - Renames the include macros to `%include...` to line up with #18.
 - Parse arguments to macros more uniformly (`selector` is still a special case.)
 - Fixes `push*` so that `push 1 99` doesn't parse any more.