### PR TITLE
Resolve ops last in parser

### DIFF
--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -2,7 +2,7 @@ program = _{ SOI ~ "\n"* ~ (stmt ~ "\n"+)* ~ stmt? ~ EOI }
 
 stmt = _{ expr }
 
-expr = _{ op | push | inst_macro | label_defn }
+expr = _{ label_defn | inst_macro | push | op }
 
 op = @{
 	"origin" | "stop" | "mulmod" | "mul" | "sub" | "div" | "sdiv" | "mod" | "smod" |
@@ -40,7 +40,7 @@ selector = { "selector(\"" ~ function_declaration ~ "\")" }
 function_declaration = { function_name ~ "(" ~ ASCII_ALPHANUMERIC* ~ ("," ~ ASCII_ALPHANUMERIC+)* ~ ")" }
 function_name = @{ ( ASCII_ALPHA | "_" ) ~ ( ASCII_ALPHANUMERIC | "_" )* }
 
-label = @{ (ASCII_ALPHA ~ "_"*) ~ (ASCII_ALPHANUMERIC | "_")* }
+label = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 label_defn = { label ~ ":" }
 
 arguments = _{ "(" ~ arguments_list? ~ ")" }

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -328,6 +328,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_push_op_as_label() {
+        let asm = r#"
+            push1:
+            push1 push1
+            jumpi
+        "#;
+        let expected = nodes![
+            AbstractOp::Label("push1".into()),
+            Op::Push1(Imm::from("push1")),
+            Op::JumpI
+        ];
+        assert_matches!(parse_asm(asm), Ok(e) if e == expected);
+    }
+
+    #[test]
     fn parse_selector() {
         let asm = r#"
             push4 selector("name()")


### PR DESCRIPTION
Before: if you tried to make a label that was a prefix of an op, it would try to parse as an op.
Now: if you make a label with the prefix of an op, it parses as a label.