### PR TITLE
Analysis - Control flow graph tool, and assorted other bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,10 +172,14 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 name = "etk-analyze"
 version = "0.2.0-dev"
 dependencies = [
+ "assert_matches",
  "etk-asm",
  "etk-cli",
  "hex",
+ "hex-literal",
+ "petgraph",
  "structopt",
+ "z3",
 ]
 
 [[package]]
@@ -208,6 +212,12 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "generic-array"
@@ -246,6 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +318,15 @@ name = "libc"
 version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "maplit"
@@ -368,6 +403,16 @@ dependencies = [
  "maplit",
  "pest",
  "sha-1",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -661,3 +706,20 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "z3"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1c80cd890d936ecafd439e757113a397f5797b12232b29c443256dd02c07b"
+dependencies = [
+ "lazy_static",
+ "log",
+ "z3-sys",
+]
+
+[[package]]
+name = "z3-sys"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa18ba5fbd4933e41ffb440c3fd91f91fe9cdb7310cce3ddfb6648563811de0"

--- a/etk-analyze/Cargo.toml
+++ b/etk-analyze/Cargo.toml
@@ -12,14 +12,29 @@ keywords = ["etk", "ethereum", "disassembler"]
 categories = ["cryptography::cryptocurrencies", "command-line-utilities", "development-tools"]
 
 [features]
-cli = ["structopt", "etk-cli"]
+cli = ["structopt", "etk-cli", "cfg"]
+cfg = ["z3", "petgraph"]
 
 [dependencies]
 hex = "0.4.3"
 etk-asm = { path = "../etk-asm", version = "0.2.0-dev" }
 structopt = { optional = true, version = "0.3.21" }
 etk-cli = { optional = true, path = "../etk-cli", version = "0.2.0-dev" }
+z3 = { optional = true, version = "0.10.0" }
+
+[dependencies.petgraph]
+optional = true
+version = "0.5.1"
+default-features = false
+
+[dev-dependencies]
+hex-literal = "0.3.1"
+assert_matches = "1.5.0"
 
 [[bin]]
 name = "disease"
+required-features = ["cli"]
+
+[[bin]]
+name = "ecfg"
 required-features = ["cli"]

--- a/etk-analyze/src/bin/ecfg.rs
+++ b/etk-analyze/src/bin/ecfg.rs
@@ -1,0 +1,67 @@
+#[path = "ecfg/opts.rs"]
+mod opts;
+
+use crate::opts::Opts;
+
+use etk_analyze::blocks::basic::Separator;
+use etk_analyze::blocks::AnnotatedBlock;
+use etk_analyze::cfg::ControlFlowGraph;
+
+use etk_asm::disasm::Disassembler;
+
+use std::fs::File;
+use std::io::Write;
+
+use structopt::StructOpt;
+
+type Error = Box<dyn std::error::Error + 'static>;
+
+fn main() {
+    let result = run();
+
+    let root = match result {
+        Ok(_) => return,
+        Err(e) => e,
+    };
+
+    let mut current = Some(&*root as &dyn std::error::Error);
+
+    while let Some(e) = current.take() {
+        eprintln!("Error: {}", e);
+        eprintln!("Caused by:");
+        current = e.source();
+    }
+
+    eprintln!("Nothing.");
+}
+
+fn run() -> Result<(), Error> {
+    let opts = Opts::from_args();
+
+    let mut input = opts.src.open()?;
+    let mut disasm = Disassembler::new();
+
+    std::io::copy(&mut input, &mut disasm)?;
+
+    let mut out: Box<dyn Write> = match opts.out_file {
+        Some(path) => Box::new(File::create(path)?),
+        None => Box::new(std::io::stdout()),
+    };
+
+    let mut separator = Separator::new();
+
+    separator.push_all(disasm.ops());
+
+    let blocks = separator
+        .take()
+        .into_iter()
+        .chain(separator.finish().into_iter())
+        .map(|x| AnnotatedBlock::annotate(&x));
+
+    let mut cfg = ControlFlowGraph::new(blocks);
+    cfg.refine_shallow();
+
+    writeln!(out, "{}", cfg.render()).unwrap();
+
+    Ok(())
+}

--- a/etk-analyze/src/bin/ecfg/opts.rs
+++ b/etk-analyze/src/bin/ecfg/opts.rs
@@ -1,0 +1,18 @@
+use etk_cli::io::InputSource;
+
+use std::path::PathBuf;
+
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Opts {
+    #[structopt(flatten)]
+    pub src: InputSource,
+
+    #[structopt(
+        short = "o",
+        long = "out-file",
+        help = "path to output file (defaults to stdout)"
+    )]
+    pub out_file: Option<PathBuf>,
+}

--- a/etk-analyze/src/blocks/annotated.rs
+++ b/etk-analyze/src/blocks/annotated.rs
@@ -385,9 +385,6 @@ impl<'a> Annotator<'a> {
                 }
                 ConcreteOp::GetPc => self.push(Expr::pc(pc as u16)),
 
-                ConcreteOp::BeginSub => {
-                    // No-op
-                }
                 ConcreteOp::JumpDest => {
                     // No-op
                 }
@@ -655,19 +652,7 @@ impl<'a> Annotator<'a> {
                     ))
                 }
 
-                ConcreteOp::JumpTo
-                | ConcreteOp::TxExecGas
-                | ConcreteOp::JumpIf
-                | ConcreteOp::JumpSub
-                | ConcreteOp::JumpSubV
-                | ConcreteOp::BeginData
-                | ConcreteOp::ReturnSub
-                | ConcreteOp::PutLocal
-                | ConcreteOp::GetLocal
-                | ConcreteOp::SLoadBytes
-                | ConcreteOp::SStoreBytes
-                | ConcreteOp::SSize
-                | ConcreteOp::Invalid
+                ConcreteOp::Invalid
                 | ConcreteOp::Invalid0c
                 | ConcreteOp::Invalid0d
                 | ConcreteOp::Invalid0e
@@ -713,8 +698,17 @@ impl<'a> Annotator<'a> {
                 | ConcreteOp::InvalidAd
                 | ConcreteOp::InvalidAe
                 | ConcreteOp::InvalidAf
+                | ConcreteOp::InvalidB0
+                | ConcreteOp::InvalidB1
+                | ConcreteOp::InvalidB2
                 | ConcreteOp::InvalidB3
+                | ConcreteOp::InvalidB4
+                | ConcreteOp::InvalidB5
+                | ConcreteOp::InvalidB6
                 | ConcreteOp::InvalidB7
+                | ConcreteOp::InvalidB8
+                | ConcreteOp::InvalidB9
+                | ConcreteOp::InvalidBa
                 | ConcreteOp::InvalidBb
                 | ConcreteOp::InvalidBc
                 | ConcreteOp::InvalidBd
@@ -753,6 +747,9 @@ impl<'a> Annotator<'a> {
                 | ConcreteOp::InvalidDe
                 | ConcreteOp::InvalidDf
                 | ConcreteOp::InvalidE0
+                | ConcreteOp::InvalidE1
+                | ConcreteOp::InvalidE2
+                | ConcreteOp::InvalidE3
                 | ConcreteOp::InvalidE4
                 | ConcreteOp::InvalidE5
                 | ConcreteOp::InvalidE6
@@ -769,7 +766,8 @@ impl<'a> Annotator<'a> {
                 | ConcreteOp::InvalidF7
                 | ConcreteOp::InvalidF8
                 | ConcreteOp::InvalidF9
-                | ConcreteOp::InvalidFb => {
+                | ConcreteOp::InvalidFb
+                | ConcreteOp::InvalidFc => {
                     assert!(is_last);
                     return Exit::Terminate;
                 }

--- a/etk-analyze/src/blocks/annotated.rs
+++ b/etk-analyze/src/blocks/annotated.rs
@@ -348,7 +348,10 @@ impl<'a> Annotator<'a> {
             }
 
             ConcreteOp::Address => stack.push(Expr::address()),
-            ConcreteOp::Balance => stack.push(Expr::balance()),
+            ConcreteOp::Balance => {
+                let address = stack.pop();
+                stack.push(Expr::balance(&address));
+            }
             ConcreteOp::Origin => stack.push(Expr::origin()),
             ConcreteOp::Caller => stack.push(Expr::caller()),
             ConcreteOp::CallValue => stack.push(Expr::call_value()),
@@ -362,7 +365,10 @@ impl<'a> Annotator<'a> {
                 let address = stack.pop();
                 stack.push(Expr::ext_code_size(&address));
             }
-            ConcreteOp::BlockHash => stack.push(Expr::block_hash()),
+            ConcreteOp::BlockHash => {
+                let address = stack.pop();
+                stack.push(Expr::block_hash(&address));
+            }
             ConcreteOp::Coinbase => stack.push(Expr::coinbase()),
             ConcreteOp::Timestamp => stack.push(Expr::timestamp()),
             ConcreteOp::Number => stack.push(Expr::number()),

--- a/etk-analyze/src/blocks/annotated.rs
+++ b/etk-analyze/src/blocks/annotated.rs
@@ -460,14 +460,14 @@ impl<'a> Annotator<'a> {
                 let _dest_offset = stack.pop();
                 let _offset = stack.pop();
                 let _len = stack.pop();
-                todo!("set memory")
+                // TODO: Set memory
             }
 
             ConcreteOp::CodeCopy => {
                 let _dest_offset = stack.pop();
                 let _offset = stack.pop();
                 let _len = stack.pop();
-                todo!("set memory")
+                // TODO: Set memory
             }
 
             ConcreteOp::ExtCodeCopy => {
@@ -475,14 +475,14 @@ impl<'a> Annotator<'a> {
                 let _dest_offset = stack.pop();
                 let _offset = stack.pop();
                 let _len = stack.pop();
-                todo!("set memory")
+                // TODO: Set memory
             }
             ConcreteOp::ReturnDataSize => stack.push(Expr::return_data_size()),
             ConcreteOp::ReturnDataCopy => {
                 let _dest_offset = stack.pop();
                 let _offset = stack.pop();
                 let _len = stack.pop();
-                todo!()
+                // TODO: Set memory
             }
             ConcreteOp::ExtCodeHash => {
                 let addr = stack.pop();
@@ -495,12 +495,12 @@ impl<'a> Annotator<'a> {
             ConcreteOp::MStore => {
                 let _addr = stack.pop();
                 let _value = stack.pop();
-                todo!("set memory");
+                // TODO: set memory
             }
             ConcreteOp::MStore8 => {
                 let _addr = stack.pop();
                 let _value = stack.pop();
-                todo!("set memory");
+                // TODO: set memory
             }
             ConcreteOp::SLoad => {
                 let addr = stack.pop();
@@ -509,7 +509,7 @@ impl<'a> Annotator<'a> {
             ConcreteOp::SStore => {
                 let _key = stack.pop();
                 let _value = stack.pop();
-                todo!("set storage");
+                // TODO: set storage
             }
             ConcreteOp::GetPc => stack.push(Expr::pc(pc as u16)),
 

--- a/etk-analyze/src/blocks/annotated.rs
+++ b/etk-analyze/src/blocks/annotated.rs
@@ -1,6 +1,6 @@
 use crate::sym::{Expr, Var};
 
-use etk_asm::ops::ConcreteOp;
+use etk_asm::ops::{ConcreteOp, Metadata};
 
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
@@ -41,10 +41,17 @@ pub struct AnnotatedBlock {
     pub inputs: Inputs,
     pub outputs: Outputs,
     pub exit: Exit,
+    pub jump_target: bool,
 }
 
 impl AnnotatedBlock {
     pub fn annotate(basic: &BasicBlock) -> Self {
+        let jump_target = basic
+            .ops
+            .get(0)
+            .map(Metadata::is_jump_target)
+            .unwrap_or_default();
+
         let mut annotator = Annotator::new(basic);
         let exit = annotator.annotate();
 
@@ -58,6 +65,7 @@ impl AnnotatedBlock {
         let stack_outputs = stacks.last().unwrap();
 
         Self {
+            jump_target,
             offset: basic.offset,
             outputs: Outputs {
                 stack: stack_outputs.into(),
@@ -71,6 +79,104 @@ impl AnnotatedBlock {
             },
             exit,
         }
+    }
+}
+
+struct StackWindow<'s> {
+    vars: &'s mut u16,
+    stacks: &'s mut Vec<VecDeque<Expr>>,
+    pops: usize,
+    pushes: usize,
+}
+
+impl<'s> Drop for StackWindow<'s> {
+    fn drop(&mut self) {
+        if !std::thread::panicking() {
+            assert_eq!(self.pops, 0);
+            assert_eq!(self.pushes, 0);
+        }
+    }
+}
+
+impl<'s> StackWindow<'s> {
+    fn new(vars: &'s mut u16, stacks: &'s mut Vec<VecDeque<Expr>>, op: &ConcreteOp) -> Self {
+        Self {
+            vars,
+            stacks,
+            pops: op.pops(),
+            pushes: op.pushes(),
+        }
+    }
+
+    fn count_pops(&mut self, count: usize) {
+        assert!(self.pops >= count);
+        self.pops -= count;
+    }
+
+    fn count_pushes(&mut self, count: usize) {
+        assert_eq!(self.pops, 0);
+        assert!(self.pushes >= count);
+        self.pushes -= count;
+    }
+
+    fn expand_stack(&mut self, by: usize) {
+        for _ in 0..by {
+            *self.vars += 1;
+            let var = Var::with_id(*self.vars);
+            for stack in self.stacks.iter_mut() {
+                stack.push_back(var.into());
+            }
+        }
+    }
+
+    fn current_stack(&mut self) -> &mut VecDeque<Expr> {
+        self.stacks.last_mut().unwrap()
+    }
+
+    fn pop(&mut self) -> Expr {
+        self.count_pops(1);
+
+        if self.current_stack().is_empty() {
+            self.expand_stack(1);
+        }
+
+        self.current_stack().pop_front().unwrap()
+    }
+
+    fn peek(&mut self, depth: usize) -> &Expr {
+        // A peek is basically N pops followed by N pushes.
+        self.count_pops(depth + 1);
+        self.count_pushes(depth + 1);
+
+        let len = self.current_stack().len();
+        if len < depth + 1 {
+            self.expand_stack(1 + depth - len);
+        }
+
+        self.current_stack().get(depth).unwrap()
+    }
+
+    fn swap(&mut self, depth: usize) {
+        // A swap is basically N pops followed by N pushes.
+        self.count_pops(depth + 1);
+        self.count_pushes(depth + 1);
+
+        let len = self.current_stack().len();
+        if len < depth + 1 {
+            self.expand_stack(1 + depth - len);
+        }
+
+        let deep = self.current_stack().swap_remove_front(depth).unwrap();
+        self.current_stack().push_front(deep);
+    }
+
+    fn push(&mut self, expr: Expr) {
+        self.count_pushes(1);
+        self.current_stack().push_front(expr);
+    }
+
+    fn push_const<A: AsRef<[u8]>>(&mut self, imm: &A) {
+        self.push(Expr::constant(imm))
     }
 }
 
@@ -95,58 +201,625 @@ impl<'a> Annotator<'a> {
         }
     }
 
-    fn expand_stack(&mut self, by: usize) {
-        for _ in 0..by {
-            self.vars += 1;
-            let var = Var::with_id(self.vars);
-            for stack in self.stacks.iter_mut() {
-                stack.push_back(var.into());
-            }
-        }
-    }
-
     fn advance(&mut self) {
         let last = self.stacks.last().cloned().unwrap_or_default();
         self.stacks.push(last);
     }
 
-    fn current_stack(&mut self) -> &mut VecDeque<Expr> {
-        self.stacks.last_mut().unwrap()
-    }
+    fn annotate_one<'s>(pc: usize, stack: &mut StackWindow<'s>, op: &ConcreteOp) -> Option<Exit> {
+        match op {
+            ConcreteOp::Stop => {
+                return Some(Exit::Terminate);
+            }
 
-    fn pop(&mut self) -> Expr {
-        if self.current_stack().is_empty() {
-            self.expand_stack(1);
+            ConcreteOp::Add => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.add(&rhs));
+            }
+
+            ConcreteOp::Mul => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.mul(&rhs));
+            }
+
+            ConcreteOp::Sub => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.sub(&rhs));
+            }
+
+            ConcreteOp::Div => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.div(&rhs));
+            }
+            ConcreteOp::SDiv => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.s_div(&rhs));
+            }
+            ConcreteOp::Mod => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.modulo(&rhs));
+            }
+            ConcreteOp::SMod => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.s_modulo(&rhs));
+            }
+            ConcreteOp::AddMod => {
+                let add0 = stack.pop();
+                let add1 = stack.pop();
+                let mod_ = stack.pop();
+                stack.push(add0.add_mod(&add1, &mod_))
+            }
+            ConcreteOp::MulMod => {
+                let add0 = stack.pop();
+                let add1 = stack.pop();
+                let mod_ = stack.pop();
+                stack.push(add0.mul_mod(&add1, &mod_))
+            }
+            ConcreteOp::Exp => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.exp(&rhs));
+            }
+            ConcreteOp::SignExtend => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.sign_extend(&rhs));
+            }
+
+            ConcreteOp::Lt => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.lt(&rhs));
+            }
+            ConcreteOp::Gt => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.gt(&rhs));
+            }
+            ConcreteOp::SLt => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.s_lt(&rhs));
+            }
+            ConcreteOp::SGt => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.s_gt(&rhs));
+            }
+            ConcreteOp::Eq => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.is_eq(&rhs));
+            }
+            ConcreteOp::IsZero => {
+                let arg = stack.pop().is_zero();
+                stack.push(arg);
+            }
+            ConcreteOp::And => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.and(&rhs));
+            }
+            ConcreteOp::Or => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.or(&rhs));
+            }
+            ConcreteOp::Xor => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.xor(&rhs));
+            }
+            ConcreteOp::Not => {
+                let arg = stack.pop().not();
+                stack.push(arg);
+            }
+            ConcreteOp::Byte => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.byte(&rhs));
+            }
+            ConcreteOp::Shl => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.shl(&rhs));
+            }
+            ConcreteOp::Shr => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.shr(&rhs));
+            }
+            ConcreteOp::Sar => {
+                let lhs = stack.pop();
+                let rhs = stack.pop();
+                stack.push(lhs.sar(&rhs));
+            }
+            ConcreteOp::Keccak256 => {
+                let offset = stack.pop();
+                let length = stack.pop();
+                stack.push(Expr::keccak256(&offset, &length));
+            }
+
+            ConcreteOp::Address => stack.push(Expr::address()),
+            ConcreteOp::Balance => stack.push(Expr::balance()),
+            ConcreteOp::Origin => stack.push(Expr::origin()),
+            ConcreteOp::Caller => stack.push(Expr::caller()),
+            ConcreteOp::CallValue => stack.push(Expr::call_value()),
+            ConcreteOp::CallDataLoad => {
+                let offset = stack.pop();
+                stack.push(Expr::call_data_load(&offset));
+            }
+            ConcreteOp::CodeSize => stack.push(Expr::code_size()),
+            ConcreteOp::GasPrice => stack.push(Expr::gas_price()),
+            ConcreteOp::ExtCodeSize => {
+                let address = stack.pop();
+                stack.push(Expr::ext_code_size(&address));
+            }
+            ConcreteOp::BlockHash => stack.push(Expr::block_hash()),
+            ConcreteOp::Coinbase => stack.push(Expr::coinbase()),
+            ConcreteOp::Timestamp => stack.push(Expr::timestamp()),
+            ConcreteOp::Number => stack.push(Expr::number()),
+            ConcreteOp::Difficulty => stack.push(Expr::difficulty()),
+            ConcreteOp::GasLimit => stack.push(Expr::gas_limit()),
+            ConcreteOp::ChainId => stack.push(Expr::chain_id()),
+
+            ConcreteOp::MSize => stack.push(Expr::m_size()),
+            ConcreteOp::Gas => stack.push(Expr::gas()),
+
+            ConcreteOp::Pop => {
+                stack.pop();
+            }
+
+            ConcreteOp::CallDataSize => stack.push(Expr::call_data_size()),
+            ConcreteOp::CallDataCopy => {
+                let _dest_offset = stack.pop();
+                let _offset = stack.pop();
+                let _len = stack.pop();
+                todo!("set memory")
+            }
+
+            ConcreteOp::CodeCopy => {
+                let _dest_offset = stack.pop();
+                let _offset = stack.pop();
+                let _len = stack.pop();
+                todo!("set memory")
+            }
+
+            ConcreteOp::ExtCodeCopy => {
+                let _addr = stack.pop();
+                let _dest_offset = stack.pop();
+                let _offset = stack.pop();
+                let _len = stack.pop();
+                todo!("set memory")
+            }
+            ConcreteOp::ReturnDataSize => stack.push(Expr::return_data_size()),
+            ConcreteOp::ReturnDataCopy => {
+                let _dest_offset = stack.pop();
+                let _offset = stack.pop();
+                let _len = stack.pop();
+                todo!()
+            }
+            ConcreteOp::ExtCodeHash => {
+                let addr = stack.pop();
+                stack.push(Expr::ext_code_hash(&addr));
+            }
+            ConcreteOp::MLoad => {
+                let addr = stack.pop();
+                stack.push(addr.m_load());
+            }
+            ConcreteOp::MStore => {
+                let _addr = stack.pop();
+                let _value = stack.pop();
+                todo!("set memory");
+            }
+            ConcreteOp::MStore8 => {
+                let _addr = stack.pop();
+                let _value = stack.pop();
+                todo!("set memory");
+            }
+            ConcreteOp::SLoad => {
+                let addr = stack.pop();
+                stack.push(addr.s_load());
+            }
+            ConcreteOp::SStore => {
+                let _key = stack.pop();
+                let _value = stack.pop();
+                todo!("set storage");
+            }
+            ConcreteOp::GetPc => stack.push(Expr::pc(pc as u16)),
+
+            ConcreteOp::JumpDest => {
+                // No-op
+            }
+
+            ConcreteOp::Push1(imm) => stack.push_const(imm),
+            ConcreteOp::Push2(imm) => stack.push_const(imm),
+            ConcreteOp::Push3(imm) => stack.push_const(imm),
+            ConcreteOp::Push4(imm) => stack.push_const(imm),
+            ConcreteOp::Push5(imm) => stack.push_const(imm),
+            ConcreteOp::Push6(imm) => stack.push_const(imm),
+            ConcreteOp::Push7(imm) => stack.push_const(imm),
+            ConcreteOp::Push8(imm) => stack.push_const(imm),
+            ConcreteOp::Push9(imm) => stack.push_const(imm),
+            ConcreteOp::Push10(imm) => stack.push_const(imm),
+            ConcreteOp::Push11(imm) => stack.push_const(imm),
+            ConcreteOp::Push12(imm) => stack.push_const(imm),
+            ConcreteOp::Push13(imm) => stack.push_const(imm),
+            ConcreteOp::Push14(imm) => stack.push_const(imm),
+            ConcreteOp::Push15(imm) => stack.push_const(imm),
+            ConcreteOp::Push16(imm) => stack.push_const(imm),
+            ConcreteOp::Push17(imm) => stack.push_const(imm),
+            ConcreteOp::Push18(imm) => stack.push_const(imm),
+            ConcreteOp::Push19(imm) => stack.push_const(imm),
+            ConcreteOp::Push20(imm) => stack.push_const(imm),
+            ConcreteOp::Push21(imm) => stack.push_const(imm),
+            ConcreteOp::Push22(imm) => stack.push_const(imm),
+            ConcreteOp::Push23(imm) => stack.push_const(imm),
+            ConcreteOp::Push24(imm) => stack.push_const(imm),
+            ConcreteOp::Push25(imm) => stack.push_const(imm),
+            ConcreteOp::Push26(imm) => stack.push_const(imm),
+            ConcreteOp::Push27(imm) => stack.push_const(imm),
+            ConcreteOp::Push28(imm) => stack.push_const(imm),
+            ConcreteOp::Push29(imm) => stack.push_const(imm),
+            ConcreteOp::Push30(imm) => stack.push_const(imm),
+            ConcreteOp::Push31(imm) => stack.push_const(imm),
+            ConcreteOp::Push32(imm) => stack.push_const(imm),
+
+            ConcreteOp::Dup1 => {
+                let arg = stack.peek(0).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup2 => {
+                let arg = stack.peek(1).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup3 => {
+                let arg = stack.peek(2).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup4 => {
+                let arg = stack.peek(3).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup5 => {
+                let arg = stack.peek(4).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup6 => {
+                let arg = stack.peek(5).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup7 => {
+                let arg = stack.peek(6).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup8 => {
+                let arg = stack.peek(7).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup9 => {
+                let arg = stack.peek(8).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup10 => {
+                let arg = stack.peek(9).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup11 => {
+                let arg = stack.peek(10).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup12 => {
+                let arg = stack.peek(11).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup13 => {
+                let arg = stack.peek(12).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup14 => {
+                let arg = stack.peek(13).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup15 => {
+                let arg = stack.peek(14).clone();
+                stack.push(arg)
+            }
+            ConcreteOp::Dup16 => {
+                let arg = stack.peek(15).clone();
+                stack.push(arg)
+            }
+
+            ConcreteOp::Log0 => {
+                let _offset = stack.pop();
+                let _length = stack.pop();
+            }
+            ConcreteOp::Log1 => {
+                let _offset = stack.pop();
+                let _length = stack.pop();
+                let _topic0 = stack.pop();
+            }
+            ConcreteOp::Log2 => {
+                let _offset = stack.pop();
+                let _length = stack.pop();
+                let _topic0 = stack.pop();
+                let _topic1 = stack.pop();
+            }
+            ConcreteOp::Log3 => {
+                let _offset = stack.pop();
+                let _length = stack.pop();
+                let _topic0 = stack.pop();
+                let _topic1 = stack.pop();
+                let _topic2 = stack.pop();
+            }
+            ConcreteOp::Log4 => {
+                let _offset = stack.pop();
+                let _length = stack.pop();
+                let _topic0 = stack.pop();
+                let _topic1 = stack.pop();
+                let _topic2 = stack.pop();
+                let _topic3 = stack.pop();
+            }
+
+            ConcreteOp::Swap1 => stack.swap(1),
+            ConcreteOp::Swap2 => stack.swap(2),
+            ConcreteOp::Swap3 => stack.swap(3),
+            ConcreteOp::Swap4 => stack.swap(4),
+            ConcreteOp::Swap5 => stack.swap(5),
+            ConcreteOp::Swap6 => stack.swap(6),
+            ConcreteOp::Swap7 => stack.swap(7),
+            ConcreteOp::Swap8 => stack.swap(8),
+            ConcreteOp::Swap9 => stack.swap(9),
+            ConcreteOp::Swap10 => stack.swap(10),
+            ConcreteOp::Swap11 => stack.swap(11),
+            ConcreteOp::Swap12 => stack.swap(12),
+            ConcreteOp::Swap13 => stack.swap(13),
+            ConcreteOp::Swap14 => stack.swap(14),
+            ConcreteOp::Swap15 => stack.swap(15),
+            ConcreteOp::Swap16 => stack.swap(16),
+
+            ConcreteOp::Revert | ConcreteOp::Return => {
+                let _offset = stack.pop();
+                let _length = stack.pop();
+                return Some(Exit::Terminate);
+            }
+
+            ConcreteOp::SelfDestruct => {
+                let _addr = stack.pop();
+                return Some(Exit::Terminate);
+            }
+
+            ConcreteOp::Jump => {
+                let dest = stack.pop();
+                return Some(Exit::Always(dest));
+            }
+
+            ConcreteOp::JumpI => {
+                let when_false = pc + 1;
+                let when_true = stack.pop();
+                let condition = stack.pop();
+                return Some(Exit::Branch {
+                    when_false,
+                    when_true,
+                    condition,
+                });
+            }
+
+            ConcreteOp::Create => {
+                let value = stack.pop();
+                let offset = stack.pop();
+                let length = stack.pop();
+                stack.push(Expr::create(&value, &offset, &length))
+            }
+
+            ConcreteOp::Call => {
+                let gas = stack.pop();
+                let addr = stack.pop();
+                let value = stack.pop();
+                let args_offset = stack.pop();
+                let args_len = stack.pop();
+                let ret_offset = stack.pop();
+                let ret_len = stack.pop();
+                stack.push(Expr::call(
+                    &gas,
+                    &addr,
+                    &value,
+                    &args_offset,
+                    &args_len,
+                    &ret_offset,
+                    &ret_len,
+                ))
+            }
+
+            ConcreteOp::CallCode => {
+                let gas = stack.pop();
+                let addr = stack.pop();
+                let value = stack.pop();
+                let args_offset = stack.pop();
+                let args_len = stack.pop();
+                let ret_offset = stack.pop();
+                let ret_len = stack.pop();
+                stack.push(Expr::call_code(
+                    &gas,
+                    &addr,
+                    &value,
+                    &args_offset,
+                    &args_len,
+                    &ret_offset,
+                    &ret_len,
+                ))
+            }
+
+            ConcreteOp::DelegateCall => {
+                let gas = stack.pop();
+                let addr = stack.pop();
+                let args_offset = stack.pop();
+                let args_len = stack.pop();
+                let ret_offset = stack.pop();
+                let ret_len = stack.pop();
+                stack.push(Expr::delegate_call(
+                    &gas,
+                    &addr,
+                    &args_offset,
+                    &args_len,
+                    &ret_offset,
+                    &ret_len,
+                ))
+            }
+
+            ConcreteOp::Create2 => {
+                let value = stack.pop();
+                let offset = stack.pop();
+                let length = stack.pop();
+                let salt = stack.pop();
+                stack.push(Expr::create2(&value, &offset, &length, &salt))
+            }
+
+            ConcreteOp::StaticCall => {
+                let gas = stack.pop();
+                let addr = stack.pop();
+                let args_offset = stack.pop();
+                let args_len = stack.pop();
+                let ret_offset = stack.pop();
+                let ret_len = stack.pop();
+                stack.push(Expr::static_call(
+                    &gas,
+                    &addr,
+                    &args_offset,
+                    &args_len,
+                    &ret_offset,
+                    &ret_len,
+                ))
+            }
+
+            ConcreteOp::Invalid
+            | ConcreteOp::Invalid0c
+            | ConcreteOp::Invalid0d
+            | ConcreteOp::Invalid0e
+            | ConcreteOp::Invalid0f
+            | ConcreteOp::Invalid1e
+            | ConcreteOp::Invalid1f
+            | ConcreteOp::Invalid21
+            | ConcreteOp::Invalid22
+            | ConcreteOp::Invalid23
+            | ConcreteOp::Invalid24
+            | ConcreteOp::Invalid25
+            | ConcreteOp::Invalid26
+            | ConcreteOp::Invalid27
+            | ConcreteOp::Invalid28
+            | ConcreteOp::Invalid29
+            | ConcreteOp::Invalid2a
+            | ConcreteOp::Invalid2b
+            | ConcreteOp::Invalid2c
+            | ConcreteOp::Invalid2d
+            | ConcreteOp::Invalid2e
+            | ConcreteOp::Invalid2f
+            | ConcreteOp::Invalid47
+            | ConcreteOp::Invalid48
+            | ConcreteOp::Invalid49
+            | ConcreteOp::Invalid4a
+            | ConcreteOp::Invalid4b
+            | ConcreteOp::Invalid4c
+            | ConcreteOp::Invalid4d
+            | ConcreteOp::Invalid4e
+            | ConcreteOp::Invalid4f
+            | ConcreteOp::Invalid5c
+            | ConcreteOp::Invalid5d
+            | ConcreteOp::Invalid5e
+            | ConcreteOp::Invalid5f
+            | ConcreteOp::InvalidA5
+            | ConcreteOp::InvalidA6
+            | ConcreteOp::InvalidA7
+            | ConcreteOp::InvalidA8
+            | ConcreteOp::InvalidA9
+            | ConcreteOp::InvalidAa
+            | ConcreteOp::InvalidAb
+            | ConcreteOp::InvalidAc
+            | ConcreteOp::InvalidAd
+            | ConcreteOp::InvalidAe
+            | ConcreteOp::InvalidAf
+            | ConcreteOp::InvalidB0
+            | ConcreteOp::InvalidB1
+            | ConcreteOp::InvalidB2
+            | ConcreteOp::InvalidB3
+            | ConcreteOp::InvalidB4
+            | ConcreteOp::InvalidB5
+            | ConcreteOp::InvalidB6
+            | ConcreteOp::InvalidB7
+            | ConcreteOp::InvalidB8
+            | ConcreteOp::InvalidB9
+            | ConcreteOp::InvalidBa
+            | ConcreteOp::InvalidBb
+            | ConcreteOp::InvalidBc
+            | ConcreteOp::InvalidBd
+            | ConcreteOp::InvalidBe
+            | ConcreteOp::InvalidBf
+            | ConcreteOp::InvalidC0
+            | ConcreteOp::InvalidC1
+            | ConcreteOp::InvalidC2
+            | ConcreteOp::InvalidC3
+            | ConcreteOp::InvalidC4
+            | ConcreteOp::InvalidC5
+            | ConcreteOp::InvalidC6
+            | ConcreteOp::InvalidC7
+            | ConcreteOp::InvalidC8
+            | ConcreteOp::InvalidC9
+            | ConcreteOp::InvalidCa
+            | ConcreteOp::InvalidCb
+            | ConcreteOp::InvalidCc
+            | ConcreteOp::InvalidCd
+            | ConcreteOp::InvalidCe
+            | ConcreteOp::InvalidCf
+            | ConcreteOp::InvalidD0
+            | ConcreteOp::InvalidD1
+            | ConcreteOp::InvalidD2
+            | ConcreteOp::InvalidD3
+            | ConcreteOp::InvalidD4
+            | ConcreteOp::InvalidD5
+            | ConcreteOp::InvalidD6
+            | ConcreteOp::InvalidD7
+            | ConcreteOp::InvalidD8
+            | ConcreteOp::InvalidD9
+            | ConcreteOp::InvalidDa
+            | ConcreteOp::InvalidDb
+            | ConcreteOp::InvalidDc
+            | ConcreteOp::InvalidDd
+            | ConcreteOp::InvalidDe
+            | ConcreteOp::InvalidDf
+            | ConcreteOp::InvalidE0
+            | ConcreteOp::InvalidE1
+            | ConcreteOp::InvalidE2
+            | ConcreteOp::InvalidE3
+            | ConcreteOp::InvalidE4
+            | ConcreteOp::InvalidE5
+            | ConcreteOp::InvalidE6
+            | ConcreteOp::InvalidE7
+            | ConcreteOp::InvalidE8
+            | ConcreteOp::InvalidE9
+            | ConcreteOp::InvalidEa
+            | ConcreteOp::InvalidEb
+            | ConcreteOp::InvalidEc
+            | ConcreteOp::InvalidEd
+            | ConcreteOp::InvalidEe
+            | ConcreteOp::InvalidEf
+            | ConcreteOp::InvalidF6
+            | ConcreteOp::InvalidF7
+            | ConcreteOp::InvalidF8
+            | ConcreteOp::InvalidF9
+            | ConcreteOp::InvalidFb
+            | ConcreteOp::InvalidFc => {
+                return Some(Exit::Terminate);
+            }
         }
 
-        self.current_stack().pop_front().unwrap()
-    }
-
-    fn peek(&mut self, depth: usize) -> &Expr {
-        let len = self.current_stack().len();
-        if len < depth + 1 {
-            self.expand_stack(1 + depth - len);
-        }
-
-        self.current_stack().get(depth).unwrap()
-    }
-
-    fn swap(&mut self, depth: usize) {
-        let len = self.current_stack().len();
-        if len < depth + 1 {
-            self.expand_stack(1 + depth - len);
-        }
-
-        let deep = self.current_stack().swap_remove_front(depth).unwrap();
-        self.current_stack().push_front(deep);
-    }
-
-    fn push(&mut self, expr: Expr) {
-        self.current_stack().push_front(expr);
-    }
-
-    fn push_const<A: AsRef<[u8]>>(&mut self, imm: &A) {
-        self.push(Expr::constant(imm))
+        None
     }
 
     pub fn annotate(&mut self) -> Exit {
@@ -156,622 +829,23 @@ impl<'a> Annotator<'a> {
             self.advance();
             let is_last = idx == self.basic.ops.len() - 1;
 
-            match op {
-                ConcreteOp::Stop => {
-                    assert!(is_last);
-                    return Exit::Terminate;
-                }
+            let mut window = StackWindow::new(&mut self.vars, &mut self.stacks, op);
 
-                ConcreteOp::Add => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.add(&rhs));
-                }
+            if let Some(exit) = Self::annotate_one(pc, &mut window, op) {
+                assert!(is_last);
 
-                ConcreteOp::Mul => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.mul(&rhs));
-                }
+                let exit_matches = match exit {
+                    Exit::Terminate => op.is_exit(),
+                    Exit::Branch { .. } => op.is_jump(),
+                    Exit::Always(_) => unreachable!(),
+                };
 
-                ConcreteOp::Sub => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.sub(&rhs));
-                }
+                assert!(exit_matches, "bug: exit type doesn't match metadata");
 
-                ConcreteOp::Div => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.div(&rhs));
-                }
-                ConcreteOp::SDiv => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.s_div(&rhs));
-                }
-                ConcreteOp::Mod => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.modulo(&rhs));
-                }
-                ConcreteOp::SMod => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.s_modulo(&rhs));
-                }
-                ConcreteOp::AddMod => {
-                    let add0 = self.pop();
-                    let add1 = self.pop();
-                    let mod_ = self.pop();
-                    self.push(add0.add_mod(&add1, &mod_))
-                }
-                ConcreteOp::MulMod => {
-                    let add0 = self.pop();
-                    let add1 = self.pop();
-                    let mod_ = self.pop();
-                    self.push(add0.mul_mod(&add1, &mod_))
-                }
-                ConcreteOp::Exp => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.exp(&rhs));
-                }
-                ConcreteOp::SignExtend => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.sign_extend(&rhs));
-                }
-
-                ConcreteOp::Lt => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.lt(&rhs));
-                }
-                ConcreteOp::Gt => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.gt(&rhs));
-                }
-                ConcreteOp::SLt => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.s_lt(&rhs));
-                }
-                ConcreteOp::SGt => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.s_gt(&rhs));
-                }
-                ConcreteOp::Eq => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.is_eq(&rhs));
-                }
-                ConcreteOp::IsZero => {
-                    let arg = self.pop().is_zero();
-                    self.push(arg);
-                }
-                ConcreteOp::And => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.and(&rhs));
-                }
-                ConcreteOp::Or => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.or(&rhs));
-                }
-                ConcreteOp::Xor => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.xor(&rhs));
-                }
-                ConcreteOp::Not => {
-                    let arg = self.pop().not();
-                    self.push(arg);
-                }
-                ConcreteOp::Byte => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.byte(&rhs));
-                }
-                ConcreteOp::Shl => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.shl(&rhs));
-                }
-                ConcreteOp::Shr => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.shr(&rhs));
-                }
-                ConcreteOp::Sar => {
-                    let lhs = self.pop();
-                    let rhs = self.pop();
-                    self.push(lhs.sar(&rhs));
-                }
-                ConcreteOp::Keccak256 => {
-                    let offset = self.pop();
-                    let length = self.pop();
-                    self.push(Expr::keccak256(&offset, &length));
-                }
-
-                ConcreteOp::Address => self.push(Expr::address()),
-                ConcreteOp::Balance => self.push(Expr::balance()),
-                ConcreteOp::Origin => self.push(Expr::origin()),
-                ConcreteOp::Caller => self.push(Expr::caller()),
-                ConcreteOp::CallValue => self.push(Expr::call_value()),
-                ConcreteOp::CallDataLoad => {
-                    let offset = self.pop();
-                    self.push(Expr::call_data_load(&offset));
-                }
-                ConcreteOp::CodeSize => self.push(Expr::code_size()),
-                ConcreteOp::GasPrice => self.push(Expr::gas_price()),
-                ConcreteOp::ExtCodeSize => {
-                    let address = self.pop();
-                    self.push(Expr::ext_code_size(&address));
-                }
-                ConcreteOp::BlockHash => self.push(Expr::block_hash()),
-                ConcreteOp::Coinbase => self.push(Expr::coinbase()),
-                ConcreteOp::Timestamp => self.push(Expr::timestamp()),
-                ConcreteOp::Number => self.push(Expr::number()),
-                ConcreteOp::Difficulty => self.push(Expr::difficulty()),
-                ConcreteOp::GasLimit => self.push(Expr::gas_limit()),
-                ConcreteOp::ChainId => self.push(Expr::chain_id()),
-
-                ConcreteOp::MSize => self.push(Expr::m_size()),
-                ConcreteOp::Gas => self.push(Expr::gas()),
-
-                ConcreteOp::Pop => {
-                    self.pop();
-                }
-
-                ConcreteOp::CallDataSize => self.push(Expr::call_data_size()),
-                ConcreteOp::CallDataCopy => {
-                    let _dest_offset = self.pop();
-                    let _offset = self.pop();
-                    let _len = self.pop();
-                    todo!("set memory")
-                }
-
-                ConcreteOp::CodeCopy => {
-                    let _dest_offset = self.pop();
-                    let _offset = self.pop();
-                    let _len = self.pop();
-                    todo!("set memory")
-                }
-
-                ConcreteOp::ExtCodeCopy => {
-                    let _addr = self.pop();
-                    let _dest_offset = self.pop();
-                    let _offset = self.pop();
-                    let _len = self.pop();
-                    todo!("set memory")
-                }
-                ConcreteOp::ReturnDataSize => self.push(Expr::return_data_size()),
-                ConcreteOp::ReturnDataCopy => {
-                    let _dest_offset = self.pop();
-                    let _offset = self.pop();
-                    let _len = self.pop();
-                    todo!()
-                }
-                ConcreteOp::ExtCodeHash => {
-                    let addr = self.pop();
-                    self.push(Expr::ext_code_hash(&addr));
-                }
-                ConcreteOp::MLoad => {
-                    let addr = self.pop();
-                    self.push(addr.m_load());
-                }
-                ConcreteOp::MStore => {
-                    let _addr = self.pop();
-                    let _value = self.pop();
-                    todo!("set memory");
-                }
-                ConcreteOp::MStore8 => {
-                    let _addr = self.pop();
-                    let _value = self.pop();
-                    todo!("set memory");
-                }
-                ConcreteOp::SLoad => {
-                    let addr = self.pop();
-                    self.push(addr.s_load());
-                }
-                ConcreteOp::SStore => {
-                    let _key = self.pop();
-                    let _value = self.pop();
-                    todo!("set storage");
-                }
-                ConcreteOp::GetPc => self.push(Expr::pc(pc as u16)),
-
-                ConcreteOp::JumpDest => {
-                    // No-op
-                }
-
-                ConcreteOp::Push1(imm) => self.push_const(imm),
-                ConcreteOp::Push2(imm) => self.push_const(imm),
-                ConcreteOp::Push3(imm) => self.push_const(imm),
-                ConcreteOp::Push4(imm) => self.push_const(imm),
-                ConcreteOp::Push5(imm) => self.push_const(imm),
-                ConcreteOp::Push6(imm) => self.push_const(imm),
-                ConcreteOp::Push7(imm) => self.push_const(imm),
-                ConcreteOp::Push8(imm) => self.push_const(imm),
-                ConcreteOp::Push9(imm) => self.push_const(imm),
-                ConcreteOp::Push10(imm) => self.push_const(imm),
-                ConcreteOp::Push11(imm) => self.push_const(imm),
-                ConcreteOp::Push12(imm) => self.push_const(imm),
-                ConcreteOp::Push13(imm) => self.push_const(imm),
-                ConcreteOp::Push14(imm) => self.push_const(imm),
-                ConcreteOp::Push15(imm) => self.push_const(imm),
-                ConcreteOp::Push16(imm) => self.push_const(imm),
-                ConcreteOp::Push17(imm) => self.push_const(imm),
-                ConcreteOp::Push18(imm) => self.push_const(imm),
-                ConcreteOp::Push19(imm) => self.push_const(imm),
-                ConcreteOp::Push20(imm) => self.push_const(imm),
-                ConcreteOp::Push21(imm) => self.push_const(imm),
-                ConcreteOp::Push22(imm) => self.push_const(imm),
-                ConcreteOp::Push23(imm) => self.push_const(imm),
-                ConcreteOp::Push24(imm) => self.push_const(imm),
-                ConcreteOp::Push25(imm) => self.push_const(imm),
-                ConcreteOp::Push26(imm) => self.push_const(imm),
-                ConcreteOp::Push27(imm) => self.push_const(imm),
-                ConcreteOp::Push28(imm) => self.push_const(imm),
-                ConcreteOp::Push29(imm) => self.push_const(imm),
-                ConcreteOp::Push30(imm) => self.push_const(imm),
-                ConcreteOp::Push31(imm) => self.push_const(imm),
-                ConcreteOp::Push32(imm) => self.push_const(imm),
-
-                ConcreteOp::Dup1 => {
-                    let arg = self.peek(0).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup2 => {
-                    let arg = self.peek(1).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup3 => {
-                    let arg = self.peek(2).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup4 => {
-                    let arg = self.peek(3).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup5 => {
-                    let arg = self.peek(4).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup6 => {
-                    let arg = self.peek(5).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup7 => {
-                    let arg = self.peek(6).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup8 => {
-                    let arg = self.peek(7).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup9 => {
-                    let arg = self.peek(8).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup10 => {
-                    let arg = self.peek(9).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup11 => {
-                    let arg = self.peek(10).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup12 => {
-                    let arg = self.peek(11).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup13 => {
-                    let arg = self.peek(12).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup14 => {
-                    let arg = self.peek(13).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup15 => {
-                    let arg = self.peek(14).clone();
-                    self.push(arg)
-                }
-                ConcreteOp::Dup16 => {
-                    let arg = self.peek(15).clone();
-                    self.push(arg)
-                }
-
-                ConcreteOp::Log0 => {
-                    let _offset = self.pop();
-                    let _length = self.pop();
-                }
-                ConcreteOp::Log1 => {
-                    let _offset = self.pop();
-                    let _length = self.pop();
-                    let _topic0 = self.pop();
-                }
-                ConcreteOp::Log2 => {
-                    let _offset = self.pop();
-                    let _length = self.pop();
-                    let _topic0 = self.pop();
-                    let _topic1 = self.pop();
-                }
-                ConcreteOp::Log3 => {
-                    let _offset = self.pop();
-                    let _length = self.pop();
-                    let _topic0 = self.pop();
-                    let _topic1 = self.pop();
-                    let _topic2 = self.pop();
-                }
-                ConcreteOp::Log4 => {
-                    let _offset = self.pop();
-                    let _length = self.pop();
-                    let _topic0 = self.pop();
-                    let _topic1 = self.pop();
-                    let _topic2 = self.pop();
-                    let _topic3 = self.pop();
-                }
-
-                ConcreteOp::Swap1 => self.swap(1),
-                ConcreteOp::Swap2 => self.swap(2),
-                ConcreteOp::Swap3 => self.swap(3),
-                ConcreteOp::Swap4 => self.swap(4),
-                ConcreteOp::Swap5 => self.swap(5),
-                ConcreteOp::Swap6 => self.swap(6),
-                ConcreteOp::Swap7 => self.swap(7),
-                ConcreteOp::Swap8 => self.swap(8),
-                ConcreteOp::Swap9 => self.swap(9),
-                ConcreteOp::Swap10 => self.swap(10),
-                ConcreteOp::Swap11 => self.swap(11),
-                ConcreteOp::Swap12 => self.swap(12),
-                ConcreteOp::Swap13 => self.swap(13),
-                ConcreteOp::Swap14 => self.swap(14),
-                ConcreteOp::Swap15 => self.swap(15),
-                ConcreteOp::Swap16 => self.swap(16),
-
-                ConcreteOp::Revert | ConcreteOp::Return => {
-                    assert!(is_last);
-                    let _offset = self.pop();
-                    let _length = self.pop();
-                    return Exit::Terminate;
-                }
-
-                ConcreteOp::SelfDestruct => {
-                    let _addr = self.pop();
-                    return Exit::Terminate;
-                }
-
-                ConcreteOp::Jump => {
-                    assert!(is_last);
-                    let dest = self.pop();
-                    return Exit::Always(dest);
-                }
-
-                ConcreteOp::JumpI => {
-                    assert!(is_last);
-                    let when_false = pc + 1;
-                    let when_true = self.pop();
-                    let condition = self.pop();
-                    return Exit::Branch {
-                        when_false,
-                        when_true,
-                        condition,
-                    };
-                }
-
-                ConcreteOp::Create => {
-                    let value = self.pop();
-                    let offset = self.pop();
-                    let length = self.pop();
-                    self.push(Expr::create(&value, &offset, &length))
-                }
-
-                ConcreteOp::Call => {
-                    let gas = self.pop();
-                    let addr = self.pop();
-                    let value = self.pop();
-                    let args_offset = self.pop();
-                    let args_len = self.pop();
-                    let ret_offset = self.pop();
-                    let ret_len = self.pop();
-                    self.push(Expr::call(
-                        &gas,
-                        &addr,
-                        &value,
-                        &args_offset,
-                        &args_len,
-                        &ret_offset,
-                        &ret_len,
-                    ))
-                }
-
-                ConcreteOp::CallCode => {
-                    let gas = self.pop();
-                    let addr = self.pop();
-                    let value = self.pop();
-                    let args_offset = self.pop();
-                    let args_len = self.pop();
-                    let ret_offset = self.pop();
-                    let ret_len = self.pop();
-                    self.push(Expr::call_code(
-                        &gas,
-                        &addr,
-                        &value,
-                        &args_offset,
-                        &args_len,
-                        &ret_offset,
-                        &ret_len,
-                    ))
-                }
-
-                ConcreteOp::DelegateCall => {
-                    let gas = self.pop();
-                    let addr = self.pop();
-                    let args_offset = self.pop();
-                    let args_len = self.pop();
-                    let ret_offset = self.pop();
-                    let ret_len = self.pop();
-                    self.push(Expr::delegate_call(
-                        &gas,
-                        &addr,
-                        &args_offset,
-                        &args_len,
-                        &ret_offset,
-                        &ret_len,
-                    ))
-                }
-
-                ConcreteOp::Create2 => {
-                    let value = self.pop();
-                    let offset = self.pop();
-                    let length = self.pop();
-                    let salt = self.pop();
-                    self.push(Expr::create2(&value, &offset, &length, &salt))
-                }
-
-                ConcreteOp::StaticCall => {
-                    let gas = self.pop();
-                    let addr = self.pop();
-                    let args_offset = self.pop();
-                    let args_len = self.pop();
-                    let ret_offset = self.pop();
-                    let ret_len = self.pop();
-                    self.push(Expr::static_call(
-                        &gas,
-                        &addr,
-                        &args_offset,
-                        &args_len,
-                        &ret_offset,
-                        &ret_len,
-                    ))
-                }
-
-                ConcreteOp::Invalid
-                | ConcreteOp::Invalid0c
-                | ConcreteOp::Invalid0d
-                | ConcreteOp::Invalid0e
-                | ConcreteOp::Invalid0f
-                | ConcreteOp::Invalid1e
-                | ConcreteOp::Invalid1f
-                | ConcreteOp::Invalid21
-                | ConcreteOp::Invalid22
-                | ConcreteOp::Invalid23
-                | ConcreteOp::Invalid24
-                | ConcreteOp::Invalid25
-                | ConcreteOp::Invalid26
-                | ConcreteOp::Invalid27
-                | ConcreteOp::Invalid28
-                | ConcreteOp::Invalid29
-                | ConcreteOp::Invalid2a
-                | ConcreteOp::Invalid2b
-                | ConcreteOp::Invalid2c
-                | ConcreteOp::Invalid2d
-                | ConcreteOp::Invalid2e
-                | ConcreteOp::Invalid2f
-                | ConcreteOp::Invalid47
-                | ConcreteOp::Invalid48
-                | ConcreteOp::Invalid49
-                | ConcreteOp::Invalid4a
-                | ConcreteOp::Invalid4b
-                | ConcreteOp::Invalid4c
-                | ConcreteOp::Invalid4d
-                | ConcreteOp::Invalid4e
-                | ConcreteOp::Invalid4f
-                | ConcreteOp::Invalid5c
-                | ConcreteOp::Invalid5d
-                | ConcreteOp::Invalid5e
-                | ConcreteOp::Invalid5f
-                | ConcreteOp::InvalidA5
-                | ConcreteOp::InvalidA6
-                | ConcreteOp::InvalidA7
-                | ConcreteOp::InvalidA8
-                | ConcreteOp::InvalidA9
-                | ConcreteOp::InvalidAa
-                | ConcreteOp::InvalidAb
-                | ConcreteOp::InvalidAc
-                | ConcreteOp::InvalidAd
-                | ConcreteOp::InvalidAe
-                | ConcreteOp::InvalidAf
-                | ConcreteOp::InvalidB0
-                | ConcreteOp::InvalidB1
-                | ConcreteOp::InvalidB2
-                | ConcreteOp::InvalidB3
-                | ConcreteOp::InvalidB4
-                | ConcreteOp::InvalidB5
-                | ConcreteOp::InvalidB6
-                | ConcreteOp::InvalidB7
-                | ConcreteOp::InvalidB8
-                | ConcreteOp::InvalidB9
-                | ConcreteOp::InvalidBa
-                | ConcreteOp::InvalidBb
-                | ConcreteOp::InvalidBc
-                | ConcreteOp::InvalidBd
-                | ConcreteOp::InvalidBe
-                | ConcreteOp::InvalidBf
-                | ConcreteOp::InvalidC0
-                | ConcreteOp::InvalidC1
-                | ConcreteOp::InvalidC2
-                | ConcreteOp::InvalidC3
-                | ConcreteOp::InvalidC4
-                | ConcreteOp::InvalidC5
-                | ConcreteOp::InvalidC6
-                | ConcreteOp::InvalidC7
-                | ConcreteOp::InvalidC8
-                | ConcreteOp::InvalidC9
-                | ConcreteOp::InvalidCa
-                | ConcreteOp::InvalidCb
-                | ConcreteOp::InvalidCc
-                | ConcreteOp::InvalidCd
-                | ConcreteOp::InvalidCe
-                | ConcreteOp::InvalidCf
-                | ConcreteOp::InvalidD0
-                | ConcreteOp::InvalidD1
-                | ConcreteOp::InvalidD2
-                | ConcreteOp::InvalidD3
-                | ConcreteOp::InvalidD4
-                | ConcreteOp::InvalidD5
-                | ConcreteOp::InvalidD6
-                | ConcreteOp::InvalidD7
-                | ConcreteOp::InvalidD8
-                | ConcreteOp::InvalidD9
-                | ConcreteOp::InvalidDa
-                | ConcreteOp::InvalidDb
-                | ConcreteOp::InvalidDc
-                | ConcreteOp::InvalidDd
-                | ConcreteOp::InvalidDe
-                | ConcreteOp::InvalidDf
-                | ConcreteOp::InvalidE0
-                | ConcreteOp::InvalidE1
-                | ConcreteOp::InvalidE2
-                | ConcreteOp::InvalidE3
-                | ConcreteOp::InvalidE4
-                | ConcreteOp::InvalidE5
-                | ConcreteOp::InvalidE6
-                | ConcreteOp::InvalidE7
-                | ConcreteOp::InvalidE8
-                | ConcreteOp::InvalidE9
-                | ConcreteOp::InvalidEa
-                | ConcreteOp::InvalidEb
-                | ConcreteOp::InvalidEc
-                | ConcreteOp::InvalidEd
-                | ConcreteOp::InvalidEe
-                | ConcreteOp::InvalidEf
-                | ConcreteOp::InvalidF6
-                | ConcreteOp::InvalidF7
-                | ConcreteOp::InvalidF8
-                | ConcreteOp::InvalidF9
-                | ConcreteOp::InvalidFb
-                | ConcreteOp::InvalidFc => {
-                    assert!(is_last);
-                    return Exit::Terminate;
-                }
+                return exit;
             }
+
+            assert!(!op.is_exit());
 
             pc += op.size() as usize;
         }

--- a/etk-analyze/src/blocks/basic.rs
+++ b/etk-analyze/src/blocks/basic.rs
@@ -1,10 +1,19 @@
 use etk_asm::disasm::Offset;
 use etk_asm::ops::{ConcreteOp, Metadata};
 
+use std::convert::TryInto;
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct BasicBlock {
     pub offset: usize,
     pub ops: Vec<ConcreteOp>,
+}
+
+impl BasicBlock {
+    pub fn size(&self) -> usize {
+        let sum: u32 = self.ops.iter().map(ConcreteOp::size).sum();
+        sum.try_into().unwrap()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/etk-analyze/src/cfg.rs
+++ b/etk-analyze/src/cfg.rs
@@ -149,7 +149,7 @@ impl ControlFlowGraph {
             }
         }
 
-        Self { graph, by_offset }
+        Self { by_offset, graph }
     }
 
     fn shallow_block(&mut self, from: NodeIndex, to: NodeIndex) -> bool {

--- a/etk-analyze/src/cfg.rs
+++ b/etk-analyze/src/cfg.rs
@@ -1,0 +1,541 @@
+use crate::blocks::annotated::{AnnotatedBlock, Exit};
+
+use petgraph::dot::Dot;
+use petgraph::graph::{Graph, NodeIndex};
+
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::fmt;
+
+use z3::ast::{Ast, BV};
+use z3::SatResult;
+
+#[derive(Debug, Clone)]
+enum Node {
+    Terminate,
+    BadJump,
+    Block(Box<AnnotatedBlock>),
+}
+
+impl fmt::Display for Node {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let block = match self {
+            Self::Terminate => return write!(f, "<terminate>"),
+            Self::BadJump => return write!(f, "<bad-jump>"),
+            Self::Block(b) => b,
+        };
+
+        write!(f, "Offset: 0x{:x}", block.offset)
+    }
+}
+
+struct Edge;
+
+impl fmt::Display for Edge {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl Node {
+    fn unwrap_block(&self) -> &AnnotatedBlock {
+        match self {
+            Self::Block(b) => b,
+            _ => panic!("not a block"),
+        }
+    }
+}
+
+pub struct ControlFlowGraph {
+    by_offset: BTreeMap<usize, NodeIndex>,
+    graph: Graph<Node, Edge>,
+}
+
+impl fmt::Debug for ControlFlowGraph {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[derive(Debug)]
+        struct ControlFlowGraph<'a> {
+            by_offset: &'a BTreeMap<usize, NodeIndex>,
+            node_count: usize,
+            edge_count: usize,
+        }
+
+        let helper = ControlFlowGraph {
+            by_offset: &self.by_offset,
+            node_count: self.graph.node_count(),
+            edge_count: self.graph.edge_count(),
+        };
+
+        helper.fmt(f)
+    }
+}
+
+impl ControlFlowGraph {
+    pub fn new<I>(blocks: I) -> Self
+    where
+        I: Iterator<Item = AnnotatedBlock>,
+    {
+        let mut graph = Graph::<Node, Edge>::new();
+        let mut by_offset = BTreeMap::new();
+        let mut jump_targets = Vec::new();
+
+        let terminate = graph.add_node(Node::Terminate);
+        let bad_jump = graph.add_node(Node::BadJump);
+
+        for block in blocks {
+            let is_jump_target = block.jump_target;
+            let offset = block.offset;
+            let idx = graph.add_node(Node::Block(Box::new(block)));
+            let replaced = by_offset.insert(offset, idx);
+            assert_eq!(replaced, None);
+
+            if is_jump_target {
+                jump_targets.push(idx);
+            }
+        }
+
+        for idx in by_offset.values() {
+            let idx = *idx;
+            let node = &graph[idx];
+
+            let block = match node {
+                Node::Block(b) => b,
+                _ => continue,
+            };
+
+            let exit = block.exit.erase();
+
+            // Add edge to fall-through (aka the next instruction after this block.)
+            if let Some(fall_through) = block.exit.fall_through() {
+                let next = by_offset.get(&fall_through);
+                if let Some(next_idx) = next {
+                    // If the fallthrough matches a block, add an edge to it.
+                    graph.add_edge(idx, *next_idx, Edge);
+                } else {
+                    // If the fallthough doesn't match a block, add an edge to
+                    // <terminate>.
+                    graph.add_edge(idx, terminate, Edge);
+                }
+            }
+
+            match exit {
+                Exit::Unconditional(_) => (),
+                Exit::Branch { .. } => (),
+                Exit::Terminate => {
+                    // Terminate isn't a jump, so it can never be a bad one.
+                    graph.add_edge(idx, terminate, Edge);
+                    continue;
+                }
+                Exit::FallThrough(_) => {
+                    // Fallthrough is never a jump, so it can never be a bad one.
+                    continue;
+                }
+            }
+
+            // Assume all jumps can be bad.
+            graph.add_edge(idx, bad_jump, Edge);
+
+            for jump_target in jump_targets.iter() {
+                // Assume all jumps can go to any jump target.
+                graph.add_edge(idx, *jump_target, Edge);
+            }
+        }
+
+        Self { graph, by_offset }
+    }
+
+    fn shallow_block(&mut self, from: NodeIndex, to: NodeIndex) -> bool {
+        let from = self.graph[from].unwrap_block();
+        let to = self.graph[to].unwrap_block();
+
+        let config = z3::Config::new();
+        let context = z3::Context::new(&config);
+        let target = BV::from_u64(&context, to.offset.try_into().unwrap(), 256);
+
+        let ast = match from.exit.to_z3(&context) {
+            Exit::Terminate => unreachable!(),
+            Exit::FallThrough(f) => {
+                return f == to.offset;
+            }
+            Exit::Unconditional(u) => u,
+            Exit::Branch {
+                when_true,
+                when_false,
+                condition,
+            } => {
+                let when_false: u64 = when_false.try_into().unwrap();
+                let when_false = BV::from_u64(&context, when_false, 256);
+                let zero = BV::from_u64(&context, 0, 256);
+                condition._eq(&zero).ite(&when_false, &when_true)
+            }
+        };
+
+        let solver = z3::Solver::new(&context);
+        solver.assert(&ast._eq(&target));
+        let result = solver.check();
+
+        !matches!(result, SatResult::Unsat)
+    }
+
+    fn shallow_bad_jump(&mut self, from: NodeIndex) -> bool {
+        let from = self.graph[from].unwrap_block();
+
+        let config = z3::Config::new();
+        let context = z3::Context::new(&config);
+        let solver = z3::Solver::new(&context);
+
+        let ast = match from.exit.to_z3(&context) {
+            Exit::FallThrough(_) => return false,
+            Exit::Terminate => unreachable!(),
+            Exit::Unconditional(u) => u,
+            Exit::Branch {
+                when_true,
+                condition,
+                ..
+            } => {
+                let zero = BV::from_u64(&context, 0, 256);
+                solver.assert(&zero._eq(&condition).not());
+                when_true
+            }
+        };
+
+        for (offset, to_idx) in self.by_offset.iter() {
+            if !self.graph[*to_idx].unwrap_block().jump_target {
+                continue;
+            }
+
+            let bv = BV::from_u64(&context, (*offset).try_into().unwrap(), 256);
+            solver.assert(&bv._eq(&ast).not());
+        }
+
+        let result = solver.check();
+
+        !matches!(result, SatResult::Unsat)
+    }
+
+    fn shallow_terminate(&mut self, from: NodeIndex) -> bool {
+        let from = self.graph[from].unwrap_block();
+
+        let config = z3::Config::new();
+        let context = z3::Context::new(&config);
+        let solver = z3::Solver::new(&context);
+
+        let ast = match from.exit.to_z3(&context) {
+            Exit::FallThrough(_) => return true,
+            Exit::Terminate => return true,
+            Exit::Unconditional(_) => unreachable!(),
+            Exit::Branch { condition, .. } => {
+                let zero = BV::from_u64(&context, 0, 256);
+                zero._eq(&condition)
+            }
+        };
+
+        solver.assert(&ast);
+        let result = solver.check();
+
+        !matches!(result, SatResult::Unsat)
+    }
+
+    pub fn refine_shallow(&mut self) {
+        let indexes: Vec<_> = self
+            .by_offset
+            .values()
+            .filter_map(|idx| {
+                let node = &self.graph[*idx];
+                match node {
+                    Node::Block(_) => Some(*idx),
+                    _ => None,
+                }
+            })
+            .collect();
+
+        for idx in indexes.into_iter() {
+            let neighbors_indexes: Vec<_> = self.graph.neighbors(idx).collect();
+
+            for neighbor_idx in neighbors_indexes.into_iter() {
+                let neighbor = &self.graph[neighbor_idx];
+
+                let keep = match neighbor {
+                    Node::Block(_) => self.shallow_block(idx, neighbor_idx),
+                    Node::BadJump => self.shallow_bad_jump(idx),
+                    Node::Terminate => self.shallow_terminate(idx),
+                };
+
+                if !keep {
+                    let edge = self.graph.find_edge(idx, neighbor_idx).unwrap();
+                    self.graph.remove_edge(edge);
+                }
+            }
+        }
+    }
+
+    pub fn render(&self) -> impl '_ + fmt::Display {
+        Dot::new(&self.graph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::blocks::basic::Separator;
+
+    use assert_matches::assert_matches;
+
+    use etk_asm::disasm::Disassembler;
+    use etk_asm::ingest::Ingest;
+
+    use super::*;
+
+    #[derive(Debug, Copy, Clone)]
+    enum N {
+        Offset(usize),
+        BadJump,
+        Terminate,
+    }
+
+    impl From<usize> for N {
+        fn from(offset: usize) -> Self {
+            Self::Offset(offset)
+        }
+    }
+
+    struct CfgTest<C, U> {
+        source: &'static str,
+        connected: C,
+        unconnected: U,
+    }
+
+    impl<C, U, Ci, Ui> CfgTest<C, U>
+    where
+        C: IntoIterator<Item = Ci>,
+        U: IntoIterator<Item = Ui>,
+        Ci: std::borrow::Borrow<(usize, N)>,
+        Ui: std::borrow::Borrow<(usize, N)>,
+    {
+        fn compile(&self) -> Disassembler {
+            let mut output = Disassembler::new();
+            Ingest::new(&mut output)
+                .ingest("./test", self.source)
+                .unwrap();
+            output
+        }
+
+        fn find_nodes(cfg: &ControlFlowGraph, from_off: usize, to_n: N) -> (NodeIndex, NodeIndex) {
+            let terminate_idx: NodeIndex = 0.into();
+            let bad_jump_idx: NodeIndex = 1.into();
+            assert_matches!(cfg.graph[terminate_idx], Node::Terminate);
+            assert_matches!(cfg.graph[bad_jump_idx], Node::BadJump);
+
+            let from_idx = cfg.by_offset[&from_off];
+            let to_idx = match to_n {
+                N::Offset(offset) => cfg.by_offset[&offset],
+                N::BadJump => bad_jump_idx,
+                N::Terminate => terminate_idx,
+            };
+
+            (from_idx, to_idx)
+        }
+
+        fn check(self) {
+            let mut program = self.compile();
+            let mut separator = Separator::new();
+
+            separator.push_all(program.ops());
+
+            let blocks = separator
+                .take()
+                .into_iter()
+                .chain(separator.finish().into_iter())
+                .map(|x| AnnotatedBlock::annotate(&x));
+
+            let mut cfg = ControlFlowGraph::new(blocks);
+            cfg.refine_shallow();
+
+            let connected = self
+                .connected
+                .into_iter()
+                .map(|x| x.borrow().clone())
+                .map(|(f, t)| Self::find_nodes(&cfg, f, t))
+                .map(|(f, t)| (f, t, true));
+
+            let unconnected = self
+                .unconnected
+                .into_iter()
+                .map(|x| x.borrow().clone())
+                .map(|(f, t)| Self::find_nodes(&cfg, f, t))
+                .map(|(f, t)| (f, t, false));
+
+            for (from_idx, to_idx, connected) in connected.chain(unconnected) {
+                let from = &cfg.graph[from_idx];
+                let to = &cfg.graph[to_idx];
+
+                let found = cfg.graph.find_edge(from_idx, to_idx).is_some();
+                if connected && !found {
+                    panic!(
+                        "edge between {} and {} was expected, but not found",
+                        from, to,
+                    );
+                } else if !connected && found {
+                    panic!(
+                        "edge between {} and {} was not expected, but was found",
+                        from, to,
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn empty() {
+        let source = "";
+
+        CfgTest {
+            source,
+            connected: &[],
+            unconnected: &[],
+        }
+        .check();
+    }
+
+    #[test]
+    fn just_stop() {
+        let source = "stop";
+
+        CfgTest {
+            source,
+            connected: &[(0, N::Terminate)],
+            unconnected: &[],
+        }
+        .check();
+    }
+
+    #[test]
+    fn just_pc() {
+        let source = "pc";
+
+        CfgTest {
+            source,
+            connected: &[(0, N::Terminate)],
+            unconnected: &[],
+        }
+        .check();
+    }
+
+    #[test]
+    fn just_bad_jump() {
+        let source = r#"
+            push1 0
+            jump
+        "#;
+
+        CfgTest {
+            source,
+            connected: &[(0, N::BadJump)],
+            unconnected: &[(0, N::Terminate), (0, N::Offset(0))],
+        }
+        .check();
+    }
+
+    #[test]
+    fn infinite_loop() {
+        let source = r#"
+            jumpdest
+            push1 0
+            jump
+        "#;
+
+        CfgTest {
+            source,
+            connected: &[(0, N::Offset(0))],
+            unconnected: &[(0, N::Terminate), (0, N::BadJump)],
+        }
+        .check();
+    }
+
+    #[test]
+    fn infinite_loop_with_branch() {
+        let source = r#"
+            jumpdest
+            push1 1
+            push1 0
+            jumpi
+        "#;
+
+        CfgTest {
+            source,
+            connected: &[(0, N::Offset(0))],
+            unconnected: &[(0, N::Terminate), (0, N::BadJump)],
+        }
+        .check();
+    }
+
+    #[test]
+    fn fallthrough_branch() {
+        let source = r#"
+            jumpdest
+            push1 0
+            push1 100
+            jumpi
+        "#;
+
+        CfgTest {
+            source,
+            connected: &[(0, N::Terminate)],
+            unconnected: &[(0, N::Offset(0)), (0, N::BadJump)],
+        }
+        .check();
+    }
+
+    #[test]
+    fn diamond_branch() {
+        let source = r#"
+            pc
+            calldataload
+            push1 target
+            jumpi
+
+            push1 exit
+            jump
+
+            target:
+                jumpdest
+                push1 exit
+                jump
+
+            exit:
+                jumpdest
+        "#;
+
+        CfgTest {
+            source,
+            connected: &[
+                (0, N::Offset(5)),
+                (0, N::Offset(8)),
+                (5, N::Offset(12)),
+                (8, N::Offset(12)),
+                (12, N::Terminate),
+            ],
+            unconnected: &[
+                (0, N::Offset(0)),
+                (0, N::Offset(12)),
+                (0, N::BadJump),
+                (0, N::Terminate),
+                (5, N::Offset(0)),
+                (5, N::Offset(5)),
+                (5, N::Offset(8)),
+                (5, N::BadJump),
+                (5, N::Terminate),
+                (8, N::Offset(0)),
+                (8, N::Offset(8)),
+                (8, N::Offset(5)),
+                (8, N::BadJump),
+                (8, N::Terminate),
+                (12, N::Offset(0)),
+                (12, N::Offset(8)),
+                (12, N::Offset(5)),
+                (12, N::Offset(12)),
+                (12, N::BadJump),
+            ],
+        }
+        .check();
+    }
+}

--- a/etk-analyze/src/lib.rs
+++ b/etk-analyze/src/lib.rs
@@ -1,4 +1,4 @@
-//! Analysis tools from the Etherem Toolkit.
+//! Analysis tools from the Ethereum Toolkit.
 //!
 //! Highly unstable and incomplete.
 
@@ -8,4 +8,6 @@
 #![deny(missing_debug_implementations)]
 
 pub mod blocks;
+#[cfg(feature = "cfg")]
+pub mod cfg;
 mod sym;

--- a/etk-analyze/src/sym.rs
+++ b/etk-analyze/src/sym.rs
@@ -60,12 +60,6 @@ impl Expr {
         }
     }
 
-    pub fn balance() -> Self {
-        Self {
-            ops: vec![Sym::Balance],
-        }
-    }
-
     pub fn origin() -> Self {
         Self {
             ops: vec![Sym::Origin],
@@ -105,12 +99,6 @@ impl Expr {
     pub fn return_data_size() -> Self {
         Self {
             ops: vec![Sym::ReturnDataSize],
-        }
-    }
-
-    pub fn block_hash() -> Self {
-        Self {
-            ops: vec![Sym::BlockHash],
         }
     }
 
@@ -340,6 +328,14 @@ impl Expr {
 
     pub fn not(&self) -> Self {
         Self::concat(Sym::Not, &[self])
+    }
+
+    pub fn block_hash(&self) -> Self {
+        Self::concat(Sym::BlockHash, &[self])
+    }
+
+    pub fn balance(&self) -> Self {
+        Self::concat(Sym::Balance, &[self])
     }
 
     pub fn call_data_load(&self) -> Self {
@@ -598,9 +594,10 @@ enum Sym {
     ExtCodeHash,
     MLoad,
     SLoad,
+    Balance,
+    BlockHash,
 
     Address,
-    Balance,
     Origin,
     Caller,
     CallValue,
@@ -608,7 +605,6 @@ enum Sym {
     CodeSize,
     GasPrice,
     ReturnDataSize,
-    BlockHash,
     Coinbase,
     Timestamp,
     Number,
@@ -662,11 +658,12 @@ impl Sym {
             | Sym::CallDataLoad
             | Sym::ExtCodeSize
             | Sym::ExtCodeHash
+            | Sym::BlockHash
+            | Sym::Balance
             | Sym::MLoad
             | Sym::SLoad => 1,
 
             Sym::Address
-            | Sym::Balance
             | Sym::Origin
             | Sym::Caller
             | Sym::CallValue
@@ -674,7 +671,6 @@ impl Sym {
             | Sym::CodeSize
             | Sym::GasPrice
             | Sym::ReturnDataSize
-            | Sym::BlockHash
             | Sym::Coinbase
             | Sym::Timestamp
             | Sym::Number

--- a/etk-analyze/src/sym.rs
+++ b/etk-analyze/src/sym.rs
@@ -164,10 +164,6 @@ impl Expr {
         Self::concat(Sym::Create2, &[value, offset, length, salt])
     }
 
-    pub fn ext_code_copy(addr: &Self, dest_offset: &Self, offset: &Self, length: &Self) -> Self {
-        Self::concat(Sym::ExtCodeCopy, &[addr, dest_offset, offset, length])
-    }
-
     pub fn call_code(
         gas: &Self,
         addr: &Self,
@@ -298,8 +294,8 @@ impl Expr {
         Self::concat(Sym::Xor, &[self, rhs])
     }
 
-    pub fn byte(&self, rhs: &Self) -> Self {
-        Self::concat(Sym::Byte, &[self, rhs])
+    pub fn byte(&self, value: &Self) -> Self {
+        Self::concat(Sym::Byte, &[self, value])
     }
 
     pub fn shl(&self, rhs: &Self) -> Self {
@@ -378,6 +374,7 @@ impl Expr {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn constant_offset<T: Into<u128>>(offset: T) -> Self {
         let offset: u128 = offset.into();
         let mut buf = [0u8; 32];
@@ -485,7 +482,6 @@ impl<'a, 'b> Visit for DisplayVisit<'a, 'b> {
             Sym::MSize => write!(self.0, "msize("),
             Sym::Gas => write!(self.0, "gas("),
             Sym::Create => write!(self.0, "create("),
-            Sym::ExtCodeCopy => write!(self.0, "extcodecopy("),
             Sym::CallCode => write!(self.0, "callcode("),
             Sym::Call => write!(self.0, "call("),
             Sym::StaticCall => write!(self.0, "staticcall("),
@@ -618,7 +614,6 @@ enum Sym {
     Create,
 
     Create2,
-    ExtCodeCopy,
 
     CallCode,
     Call,
@@ -685,11 +680,424 @@ impl Sym {
 
             Sym::AddMod | Sym::MulMod | Sym::Create => 3,
 
-            Sym::ExtCodeCopy | Sym::Create2 => 4,
+            Sym::Create2 => 4,
 
             Sym::Call | Sym::CallCode => 7,
 
             Sym::DelegateCall | Sym::StaticCall => 6,
+        }
+    }
+}
+
+#[cfg(feature = "z3")]
+mod z3_visit {
+    use super::*;
+
+    use z3::ast::{Ast, Dynamic, BV};
+    use z3::{FuncDecl, Sort};
+
+    impl Expr {
+        pub(crate) fn to_z3<'z>(&self, context: &'z z3::Context) -> BV<'z> {
+            let mut visitor = Z3Visit {
+                context,
+                arguments: vec![],
+            };
+
+            self.walk(&mut visitor).unwrap();
+
+            assert_eq!(visitor.arguments.len(), 1);
+            visitor.arguments.remove(0)
+        }
+    }
+
+    struct Z3Visit<'z> {
+        context: &'z z3::Context,
+        arguments: Vec<BV<'z>>,
+    }
+
+    impl<'z> Z3Visit<'z> {
+        fn make_const(&self, bytes: &[u8; 32]) -> BV<'z> {
+            // TODO: This is absolutely not the right way to do this.
+            let u0 = u64::from_be_bytes(bytes[0..8].try_into().unwrap());
+            let u1 = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
+            let u2 = u64::from_be_bytes(bytes[16..24].try_into().unwrap());
+            let u3 = u64::from_be_bytes(bytes[24..32].try_into().unwrap());
+
+            let bv0 = BV::from_u64(self.context, u0, 64);
+            let bv1 = BV::from_u64(self.context, u1, 64);
+            let bv2 = BV::from_u64(self.context, u2, 64);
+            let bv3 = BV::from_u64(self.context, u3, 64);
+
+            bv0.concat(&bv1).concat(&bv2).concat(&bv3).simplify()
+        }
+
+        fn make_var(&self, var: &Var) -> BV<'z> {
+            let name = format!("etk{}", var.0);
+            BV::new_const(self.context, name, 256)
+        }
+
+        fn make_address(&self, name: &str) -> BV<'z> {
+            // TODO: Addresses are only 160 bytes.
+            BV::new_const(self.context, name, 256)
+        }
+    }
+
+    impl<'z> Visit for Z3Visit<'z> {
+        type Error = std::convert::Infallible;
+
+        fn exit(&mut self, sym: &Sym) -> Result<(), Self::Error> {
+            let node = match sym {
+                Sym::Const(value) => self.make_const(value),
+                Sym::Var(var) => self.make_var(var),
+
+                Sym::Address => self.make_address("address"),
+                Sym::Origin => self.make_address("origin"),
+                Sym::Caller => self.make_address("caller"),
+                Sym::CallValue => BV::new_const(self.context, "callvalue", 256),
+                Sym::CallDataSize => BV::new_const(self.context, "calldatasize", 256),
+                Sym::CodeSize => BV::new_const(self.context, "codesize", 256),
+                Sym::GasPrice => BV::new_const(self.context, "gasprice", 256),
+                Sym::ReturnDataSize => BV::fresh_const(self.context, "returndatasize", 256),
+                Sym::Coinbase => self.make_address("coinbase"),
+                Sym::Timestamp => BV::new_const(self.context, "timestamp", 256),
+                Sym::Number => BV::new_const(self.context, "number", 256),
+                Sym::Difficulty => BV::new_const(self.context, "difficulty", 256),
+                Sym::GasLimit => BV::new_const(self.context, "gaslimit", 256),
+                Sym::ChainId => BV::new_const(self.context, "chainid", 256),
+                Sym::GetPc(pc) => BV::from_u64(self.context, *pc as u64, 256),
+                Sym::MSize => BV::fresh_const(self.context, "msize", 256),
+                Sym::Gas => BV::fresh_const(self.context, "gas", 256),
+
+                Sym::Add => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs + rhs
+                }
+
+                Sym::Sub => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs - rhs
+                }
+
+                Sym::Mul => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs * rhs
+                }
+
+                Sym::Div => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    rhs._eq(&zero).ite(&zero, &lhs.bvudiv(&rhs))
+                }
+
+                Sym::SDiv => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    rhs._eq(&zero).ite(&zero, &lhs.bvsdiv(&rhs))
+                }
+
+                Sym::Mod => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    rhs._eq(&zero).ite(&zero, &lhs.bvurem(&rhs))
+                }
+
+                Sym::SMod => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    rhs._eq(&zero).ite(&zero, &lhs.bvsmod(&rhs))
+                }
+
+                Sym::Exp => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    // TODO: Probably incorrect, certainly inefficient.
+                    //       Something something discrete log problem?
+                    lhs.to_int(false).power(&rhs.to_int(false)).to_ast(256)
+                }
+
+                Sym::Lt => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvult(&rhs).ite(
+                        &BV::from_u64(&self.context, 1, 256),
+                        &BV::from_u64(&self.context, 0, 256),
+                    )
+                }
+
+                Sym::Gt => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvugt(&rhs).ite(
+                        &BV::from_u64(&self.context, 1, 256),
+                        &BV::from_u64(&self.context, 0, 256),
+                    )
+                }
+
+                Sym::SLt => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvslt(&rhs).ite(
+                        &BV::from_u64(&self.context, 1, 256),
+                        &BV::from_u64(&self.context, 0, 256),
+                    )
+                }
+
+                Sym::SGt => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvsgt(&rhs).ite(
+                        &BV::from_u64(&self.context, 1, 256),
+                        &BV::from_u64(&self.context, 0, 256),
+                    )
+                }
+
+                Sym::Eq => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs._eq(&rhs).ite(
+                        &BV::from_u64(&self.context, 1, 256),
+                        &BV::from_u64(&self.context, 0, 256),
+                    )
+                }
+
+                Sym::And => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvand(&rhs)
+                }
+
+                Sym::Or => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvor(&rhs)
+                }
+
+                Sym::Xor => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvxor(&rhs)
+                }
+
+                Sym::Shl => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvshl(&rhs)
+                }
+
+                Sym::Shr => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvlshr(&rhs)
+                }
+
+                Sym::Sar => {
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    lhs.bvashr(&rhs)
+                }
+
+                Sym::Not => {
+                    let arg = self.arguments.pop().unwrap();
+                    arg.bvnot()
+                }
+
+                Sym::IsZero => {
+                    let arg = self.arguments.pop().unwrap();
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    arg._eq(&zero).ite(
+                        &BV::from_u64(&self.context, 1, 256),
+                        &BV::from_u64(&self.context, 0, 256),
+                    )
+                }
+
+                Sym::Keccak256 => {
+                    let _offset = self.arguments.pop().unwrap();
+                    let _len = self.arguments.pop().unwrap();
+
+                    // TODO: Better handling, once memory is implemented.
+                    BV::fresh_const(self.context, "keccak256", 256)
+                }
+
+                Sym::SignExtend => {
+                    let _bits = self.arguments.pop().unwrap();
+                    let _value = self.arguments.pop().unwrap();
+
+                    todo!()
+                }
+
+                Sym::CallDataLoad => {
+                    let offset = self.arguments.pop().unwrap();
+
+                    let sort = Sort::bitvector(&self.context, 256);
+
+                    let func = FuncDecl::new(&self.context, "calldataload", &[&sort], &sort);
+
+                    let apply = func.apply(&[&Dynamic::from_ast(&offset)]);
+                    apply.as_bv().unwrap()
+                }
+
+                Sym::ExtCodeSize => {
+                    let _addr = self.arguments.pop().unwrap();
+                    BV::fresh_const(self.context, "extcodesize", 256)
+                }
+
+                Sym::ExtCodeHash => {
+                    let _addr = self.arguments.pop().unwrap();
+                    BV::fresh_const(self.context, "extcodehash", 256)
+                }
+
+                Sym::MLoad => {
+                    let _addr = self.arguments.pop().unwrap();
+                    BV::fresh_const(self.context, "mload", 256)
+                }
+
+                Sym::SLoad => {
+                    let _addr = self.arguments.pop().unwrap();
+                    BV::fresh_const(self.context, "sload", 256)
+                }
+
+                Sym::Balance => {
+                    let _addr = self.arguments.pop().unwrap();
+                    BV::fresh_const(self.context, "balance", 256)
+                }
+
+                Sym::BlockHash => {
+                    let num = self.arguments.pop().unwrap();
+
+                    let sort = Sort::bitvector(&self.context, 256);
+
+                    let func = FuncDecl::new(&self.context, "blockhash", &[&sort], &sort);
+
+                    let apply = func.apply(&[&Dynamic::from_ast(&num)]);
+                    apply.as_bv().unwrap()
+                }
+
+                Sym::AddMod => {
+                    let modulus = self.arguments.pop().unwrap();
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    let addmod = (rhs + lhs).bvurem(&modulus);
+                    modulus._eq(&zero).ite(&zero, &addmod)
+                }
+
+                Sym::MulMod => {
+                    let modulus = self.arguments.pop().unwrap();
+                    let rhs = self.arguments.pop().unwrap();
+                    let lhs = self.arguments.pop().unwrap();
+
+                    let zero = BV::from_u64(self.context, 0, 256);
+                    let addmod = (rhs * lhs).bvurem(&modulus);
+                    modulus._eq(&zero).ite(&zero, &addmod)
+                }
+
+                Sym::Create => {
+                    let _length = self.arguments.pop();
+                    let _offset = self.arguments.pop();
+                    let _value = self.arguments.pop();
+
+                    BV::fresh_const(self.context, "create", 256)
+                }
+
+                Sym::Create2 => {
+                    let _salt = self.arguments.pop();
+                    let _length = self.arguments.pop();
+                    let _offset = self.arguments.pop();
+                    let _value = self.arguments.pop();
+
+                    BV::fresh_const(self.context, "create2", 256)
+                }
+
+                Sym::CallCode => {
+                    let _ret_len = self.arguments.pop();
+                    let _ret_offset = self.arguments.pop();
+                    let _args_len = self.arguments.pop();
+                    let _args_offset = self.arguments.pop();
+                    let _value = self.arguments.pop();
+                    let _addr = self.arguments.pop();
+                    let _gas = self.arguments.pop();
+
+                    BV::fresh_const(self.context, "callcode", 256)
+                }
+
+                Sym::Call => {
+                    let _ret_len = self.arguments.pop();
+                    let _ret_offset = self.arguments.pop();
+                    let _args_len = self.arguments.pop();
+                    let _args_offset = self.arguments.pop();
+                    let _value = self.arguments.pop();
+                    let _addr = self.arguments.pop();
+                    let _gas = self.arguments.pop();
+
+                    BV::fresh_const(self.context, "call", 256)
+                }
+
+                Sym::StaticCall => {
+                    let _ret_len = self.arguments.pop();
+                    let _ret_offset = self.arguments.pop();
+                    let _args_len = self.arguments.pop();
+                    let _args_offset = self.arguments.pop();
+                    let _addr = self.arguments.pop();
+                    let _gas = self.arguments.pop();
+
+                    BV::fresh_const(self.context, "staticcall", 256)
+                }
+
+                Sym::DelegateCall => {
+                    let _ret_len = self.arguments.pop();
+                    let _ret_offset = self.arguments.pop();
+                    let _args_len = self.arguments.pop();
+                    let _args_offset = self.arguments.pop();
+                    let _addr = self.arguments.pop();
+                    let _gas = self.arguments.pop();
+
+                    BV::fresh_const(self.context, "delegatecall", 256)
+                }
+
+                Sym::Byte => {
+                    let value = self.arguments.pop().unwrap();
+                    let position = self.arguments.pop().unwrap();
+
+                    let c248 = BV::from_u64(self.context, 248, 256);
+                    let c8 = BV::from_u64(self.context, 8, 256);
+                    let c255 = BV::from_u64(self.context, 255, 256);
+
+                    let shift = c248 - (position * c8);
+                    let shifted = value.bvlshr(&shift);
+
+                    shifted.bvand(&c255)
+                }
+            };
+
+            self.arguments.push(node);
+            Ok(())
         }
     }
 }
@@ -745,5 +1153,721 @@ mod tests {
 
         let actual = input.to_string();
         assert_eq!(expected, actual);
+    }
+}
+
+#[cfg(all(test, feature = "z3"))]
+mod z3_tests {
+    use hex_literal::hex;
+
+    use super::*;
+
+    use z3::ast::{Ast, BV};
+    use z3::SatResult;
+
+    #[test]
+    fn sym_to_z3_const() {
+        let bytes: [u8; 32] =
+            hex!("abcdef0123456789aabbccddeeff001122334455667788999876543210fedcba");
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(bytes)
+            .to_z3(&ctx)
+            .bvadd(&BV::from_u64(&ctx, 1, 256)); // Add 1 to check endianness.
+
+        let expected_highest = BV::from_u64(&ctx, 0xabcdef0123456789, 64);
+        let expected_higher = BV::from_u64(&ctx, 0xaabbccddeeff0011, 64);
+        let expected_lower = BV::from_u64(&ctx, 0x2233445566778899, 64);
+        let expected_lowest = BV::from_u64(&ctx, 0x9876543210fedcbb, 64);
+
+        let actual_lowest = expr.extract(63, 0);
+        let actual_lower = expr.extract(127, 64);
+        let actual_higher = expr.extract(191, 128);
+        let actual_highest = expr.extract(255, 192);
+
+        // TODO: So this is probably overkill, buuuuut that's fine.
+        let solver = z3::Solver::new(&ctx);
+        solver.assert(&actual_highest._eq(&expected_highest));
+        solver.assert(&actual_higher._eq(&expected_higher));
+        solver.assert(&actual_lower._eq(&expected_lower));
+        solver.assert(&actual_lowest._eq(&expected_lowest));
+
+        assert_eq!(SatResult::Sat, solver.check());
+    }
+
+    #[test]
+    fn add_one_and_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).add(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(3));
+    }
+
+    #[test]
+    fn add_one_and_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).add(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn sub_two_from_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).sub(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(1));
+    }
+
+    #[test]
+    fn sub_max_from_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).sub(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(4));
+    }
+
+    #[test]
+    fn mul_three_by_four() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).mul(&Expr::constant(&[4]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(12));
+    }
+
+    #[test]
+    fn mul_max_by_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).mul(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(1));
+    }
+
+    #[test]
+    fn div_max_by_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).div(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(1));
+    }
+
+    #[test]
+    fn div_one_by_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).div(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn div_zero_by_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0]).div(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn div_zero_by_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0]).div(&Expr::constant(&[1]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn sdiv_max_by_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).s_div(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(1));
+    }
+
+    #[test]
+    fn sdiv_zero_by_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0]).s_div(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn sdiv_one_by_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).s_div(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+
+        let expected = Expr::constant(&[0xff; 32]).to_z3(&ctx);
+
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn mod_three_by_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).modulo(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+
+        let expected = BV::from_u64(&ctx, 1, 256);
+
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn mod_three_by_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).modulo(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+
+        let expected = BV::from_u64(&ctx, 0, 256);
+
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn mod_one_by_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).modulo(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+
+        let expected = BV::from_u64(&ctx, 1, 256);
+
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn mod_max_by_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).modulo(&Expr::constant(&[1]));
+        let ast = expr.to_z3(&ctx).simplify();
+
+        let expected = BV::from_u64(&ctx, 0, 256);
+
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn smod_zero_by_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0]).s_modulo(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn smod_one_by_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).s_modulo(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn smod_neg_one_by_neg_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let mut neg_two = [0xff; 32];
+        neg_two[31] = 0xfe;
+
+        let expr = Expr::constant(&[0xff; 32]).s_modulo(&Expr::constant(&neg_two));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = Expr::constant(&[0xff; 32]).to_z3(&ctx);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn smod_neg_two_by_neg_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let mut neg_two = [0xff; 32];
+        neg_two[31] = 0xfe;
+
+        let expr = Expr::constant(&neg_two).s_modulo(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn exp_three_raised_four() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).exp(&Expr::constant(&[4]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(0x51));
+    }
+
+    #[test]
+    fn exp_three_raised_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).exp(&Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        assert_eq!(ast.as_u64(), Some(1));
+    }
+
+    #[test]
+    fn exp_max_raised_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).exp(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+
+        let solver = z3::Solver::new(&ctx);
+        solver.assert(&ast._eq(&expected));
+
+        assert_eq!(SatResult::Sat, solver.check());
+    }
+
+    #[test]
+    fn two_lt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[2]).lt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_lt_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).lt(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_lt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).lt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn two_gt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[2]).gt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_gt_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).gt(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_gt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).gt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn two_sgt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[2]).s_gt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_sgt_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).s_gt(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_sgt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).s_gt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_sgt_neg_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).s_gt(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn two_slt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[2]).s_lt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_slt_two() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).s_lt(&Expr::constant(&[2]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_slt_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).s_lt(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_slt_neg_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).s_lt(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_eq_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).is_eq(&Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_eq_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).is_eq(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_and_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).and(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 3, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_and_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).and(&Expr::constant(&[1]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_or_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).or(&Expr::constant(&[0xff; 32]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = Expr::constant(&[0xff; 32]).to_z3(&ctx);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn four_or_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[4]).or(&Expr::constant(&[1]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 5, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn three_xor_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[3]).xor(&Expr::constant(&[1]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 2, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn byte_32() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let value: [_; 32] =
+            hex!("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+        let expr = Expr::constant(&[32]).byte(&Expr::constant(&value));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0x0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn byte_31() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let value: [_; 32] =
+            hex!("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+        let expr = Expr::constant(&[31]).byte(&Expr::constant(&value));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0xff, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn byte_30() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let value: [_; 32] =
+            hex!("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+        let expr = Expr::constant(&[30]).byte(&Expr::constant(&value));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0xee, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn byte_0() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let value: [_; 32] =
+            hex!("AB112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+        let expr = Expr::constant(&[0]).byte(&Expr::constant(&value));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0xab, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn shl_one_by_four() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).shl(&Expr::constant(&[4]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0x10, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn shr_max_by_248() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).shr(&Expr::constant(&[248]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0xff, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn sar_max_by_248() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).sar(&Expr::constant(&[248]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = Expr::constant(&[0xff; 32]).to_z3(&ctx);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn sar_one_by_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).sar(&Expr::constant(&[1]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn is_zero_one() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[1]).is_zero();
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn is_zero_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0]).is_zero();
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn not_max() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[0xff; 32]).not();
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn add_mod_five_and_eight_mod_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[5]).add_mod(&Expr::constant(&[8]), &Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn add_mod_five_and_eight_mod_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[5]).add_mod(&Expr::constant(&[8]), &Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn mul_mod_five_and_eight_mod_three() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[5]).mul_mod(&Expr::constant(&[8]), &Expr::constant(&[3]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 1, 256);
+        assert_eq!(ast, expected);
+    }
+
+    #[test]
+    fn mul_mod_five_and_eight_mod_zero() {
+        let config = z3::Config::new();
+        let ctx = z3::Context::new(&config);
+
+        let expr = Expr::constant(&[5]).mul_mod(&Expr::constant(&[8]), &Expr::constant(&[0]));
+        let ast = expr.to_z3(&ctx).simplify();
+        let expected = BV::from_u64(&ctx, 0, 256);
+        assert_eq!(ast, expected);
     }
 }

--- a/etk-asm/src/ops/imm.rs
+++ b/etk-asm/src/ops/imm.rs
@@ -231,3 +231,18 @@ pub trait Immediate<const N: usize>: Debug + Clone + Eq + PartialEq {
 impl<T, const N: usize> Immediate<N> for [T; N] where T: Debug + Clone + Eq + PartialEq {}
 impl<const N: usize> Immediate<N> for Imm<[u8; N]> {}
 impl<const N: usize> Immediate<N> for () {}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use hex_literal::hex;
+
+    use super::*;
+
+    #[test]
+    fn imm4_from_array() {
+        let imm = Imm::from(hex!("95ea7b30"));
+        assert_matches!(imm, Imm::Constant([0x95, 0xea, 0x7b, 0x30]));
+    }
+}

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -348,13 +348,14 @@ mod tests {
             push4 selector("name()")
             push4 selector("balanceOf(address)")
             push4 selector("transfer(address,uint256)")
+            push4 selector("approve(address,uint256)")
             push32 selector("transfer(address,uint256)")
-
         "#;
         let expected = nodes![
             Op::Push4(Imm::from(hex!("06fdde03"))),
             Op::Push4(Imm::from(hex!("70a08231"))),
             Op::Push4(Imm::from(hex!("a9059cbb"))),
+            Op::Push4(Imm::from(hex!("095ea7b3"))),
             Op::Push32(Imm::from(hex!(
                 "a9059cbb2ab09eb219583f4a59a5d0623ade346d962bcd4e46b11da047c9049b"
             ))),


### PR DESCRIPTION
This adds some runtime checks to the analyzer to make sure it correctly pops and pushes the right number of stack elements, relative to the definitions in etk-asm.

It also fixes the balance and blockhash opcodes so they correctly take an argument.

Finally, this adds support for control flow graph generation.