### PR TITLE
use `#` for comments and `;` as delimiter for single line expressions

### DIFF
--- a/doc/src/ch02-lang/README.md
+++ b/doc/src/ch02-lang/README.md
@@ -26,7 +26,7 @@ loop:
     jumpi
 
 pop
-stop                ; This halts execution
+stop                # This halts execution
 # "#;
 # let mut ingest = etk_asm::ingest::Ingest::new(Vec::new());
 # ingest.ingest(file!(), src).unwrap();

--- a/doc/src/ch02-lang/ch02-labels.md
+++ b/doc/src/ch02-lang/ch02-labels.md
@@ -5,16 +5,16 @@ Manually counting out jump destination addresses would be a monumentally pointle
 ```rust
 # extern crate etk_asm;
 # let src = r#"
-label0:             ; <- This is a label called "label0",
-                    ;    and it has the value 0, since it is
-                    ;    before any instructions in scope.
+label0:             # <- This is a label called "label0",
+                    #    and it has the value 0, since it is
+                    #    before any instructions in scope.
 
     jumpdest
-    push1 label0    ; <- Here we push the value of "label0",
-                    ;    which is zero, onto the stack.
+    push1 label0    # <- Here we push the value of "label0",
+                    #    which is zero, onto the stack.
 
-    jump            ; Now we jump to zero, which is a
-                    ; `jumpdest` instruction, looping forever.
+    jump            # Now we jump to zero, which is a
+                    # `jumpdest` instruction, looping forever.
 # "#;
 # let mut ingest = etk_asm::ingest::Ingest::new(Vec::new());
 # ingest.ingest(file!(), src).unwrap();
@@ -37,7 +37,7 @@ That's not all! You can also use labels to calculate lengths:
 # let src = r#"
 push1 start
 push1 end
-sub                 ; <- Will leave a 3 on the stack.
+sub                 # <- Will leave a 3 on the stack.
 stop
 
 start:

--- a/doc/src/ch02-lang/ch02-labels.md
+++ b/doc/src/ch02-lang/ch02-labels.md
@@ -6,15 +6,15 @@ Manually counting out jump destination addresses would be a monumentally pointle
 # extern crate etk_asm;
 # let src = r#"
 label0:             # <- This is a label called "label0",
-                    #    and it has the value 0, since it is
-                    #    before any instructions in scope.
+                    ##    and it has the value 0, since it is
+                    ##    before any instructions in scope.
 
     jumpdest
     push1 label0    # <- Here we push the value of "label0",
-                    #    which is zero, onto the stack.
+                    ##    which is zero, onto the stack.
 
     jump            # Now we jump to zero, which is a
-                    # `jumpdest` instruction, looping forever.
+                    ## `jumpdest` instruction, looping forever.
 # "#;
 # let mut ingest = etk_asm::ingest::Ingest::new(Vec::new());
 # ingest.ingest(file!(), src).unwrap();

--- a/doc/src/ch02-lang/ch03-macros/ch01-builtins.md
+++ b/doc/src/ch02-lang/ch03-macros/ch01-builtins.md
@@ -47,8 +47,8 @@ The path is resolved relative to the current file.
 #### Source: `main.etk`
 
 ```ignore
-some_label:                 ; <- Not visible in `other.etk`.
-    push1 some_label        ; <- Pushes a zero on the stack.
+some_label:                 # <- Not visible in `other.etk`.
+    push1 some_label        # <- Pushes a zero on the stack.
 
 %include("other.etk")
 ```
@@ -56,8 +56,8 @@ some_label:                 ; <- Not visible in `other.etk`.
 #### Source: `other.etk`
 
 ```ignore
-different_label:            ; <- Not visible in `main.etk`.
-    push1 different_label   ; <- ALSO pushes a zero on the stack.
+different_label:            # <- Not visible in `main.etk`.
+    push1 different_label   # <- ALSO pushes a zero on the stack.
 ```
 
 #### After Expansion
@@ -109,7 +109,7 @@ For example:
 ```rust
 # extern crate etk_asm;
 # let src = r#"
-push4 selector("_burn(address,bytes32,uint256)")    ; <- expands to 0x63936327
+push4 selector("_burn(address,bytes32,uint256)")    # <- expands to 0x63936327
 # "#;
 # let mut output = Vec::new();
 # let mut ingest = etk_asm::ingest::Ingest::new(&mut output);

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -1,4 +1,4 @@
-program = _{ SOI ~ "\n"* ~ (stmt ~ "\n"+)* ~ stmt? ~ EOI }
+program = _{ SOI ~ NEWLINE* ~ (stmt ~ (NEWLINE+|";"))* ~ stmt? ~ EOI }
 
 stmt = _{ expr }
 
@@ -57,4 +57,4 @@ include_hex = !{ "include_hex" ~ arguments }
 push_macro = !{ "push" ~ arguments }
 
 WHITESPACE = _{ " " | "\t" }
-COMMENT = _{ ";" ~ (!"\n" ~ ANY)* }
+COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -191,9 +191,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_single_line() {
+        let asm = r#"
+            push1 0b0; push1 0b1
+        "#;
+        let expected = nodes![Op::Push1(Imm::from([0])), Op::Push1(Imm::from([1]))];
+        assert_matches!(parse_asm(asm), Ok(e) if e == expected);
+    }
+
+    #[test]
+    fn parse_mixed_lines() {
+        let asm = r#"
+            push1 0b0; push1 0b1
+            push1 0b1
+        "#;
+        let expected = nodes![
+            Op::Push1(Imm::from([0])),
+            Op::Push1(Imm::from([1])),
+            Op::Push1(Imm::from([1]))
+        ];
+        assert_matches!(parse_asm(asm), Ok(e) if e == expected);
+    }
+
+    #[test]
     fn parse_push_binary() {
         let asm = r#"
-            ; simple cases
+            # simple cases
             push1 0b0
             push1 0b1
         "#;
@@ -204,7 +227,7 @@ mod tests {
     #[test]
     fn parse_push_octal() {
         let asm = r#"
-            ; simple cases
+            # simple cases
             push1 0o0
             push1 0o7
             push2 0o400
@@ -220,17 +243,17 @@ mod tests {
     #[test]
     fn parse_push_decimal() {
         let asm = r#"
-            ; simple cases
+            # simple cases
             push1 0
             push1 1
 
-            ; left-pad values too small
+            # left-pad values too small
             push2 42
 
-            ; barely enough for 2 bytes
+            # barely enough for 2 bytes
             push2 256
 
-            ; just enough for 4 bytes
+            # just enough for 4 bytes
             push4 4294967295
         "#;
         let expected = nodes![
@@ -249,7 +272,7 @@ mod tests {
     #[test]
     fn parse_push_hex() {
         let asm = r#"
-            push1 0x01 ; comment
+            push1 0x01 # comment
             push1 0x42
             push2 0x0102
             push4 0x01020304

--- a/etk-asm/tests/asm/simple-constructor/ctor.etk
+++ b/etk-asm/tests/asm/simple-constructor/ctor.etk
@@ -1,19 +1,19 @@
-; -- Instructions --            -- Current stack layout --
+# -- Instructions --            -- Current stack layout --
 
-pc                              ; [0]
-pc                              ; [1, 0]
-push1 start                     ; [start, 1, 0]
-add                             ; [start+1, 0]
-dup1                            ; [start+1, start+1, 0]
-codesize                        ; [codesize, start+1, start+1, 0]
-sub                             ; [length, start+1, 0]
-swap2                           ; [0, start+1, length]
-swap1                           ; [start+1, 0, length]
-dup3                            ; [length, start+1, 0, length]
-swap1                           ; [start+1, length, 0, length]
-dup3                            ; [0, start+1, length, 0, length]
-codecopy                        ; [0, length]
-return                          ; []
+pc                              # [0]
+pc                              # [1, 0]
+push1 start                     # [start, 1, 0]
+add                             # [start+1, 0]
+dup1                            # [start+1, start+1, 0]
+codesize                        # [codesize, start+1, start+1, 0]
+sub                             # [length, start+1, 0]
+swap2                           # [0, start+1, length]
+swap1                           # [start+1, 0, length]
+dup3                            # [length, start+1, 0, length]
+swap1                           # [start+1, length, 0, length]
+dup3                            # [0, start+1, length, 0, length]
+codecopy                        # [0, length]
+return                          # []
 
 start:
 %include("main.etk")

--- a/etk-asm/tests/asm/simple-constructor/main.etk
+++ b/etk-asm/tests/asm/simple-constructor/main.etk
@@ -1,6 +1,6 @@
-;;;
-; Hello World
-;;;
+###
+# Hello World
+###
 
 push1 32
 push1 31


### PR DESCRIPTION
This PR should allow to write one-liners as outlined in #43 such as

```
push1 42; push1 13; sstore;
```

```
push1 42; push1 13; sstore
```

```
push1 42; push1 13; sstore
push1 42
```