### PR TITLE
Require `etk-asm` as dev dependency in `etk-analyze`

### DIFF
--- a/etk-analyze/Cargo.toml
+++ b/etk-analyze/Cargo.toml
@@ -27,8 +27,9 @@ version = "0.5.1"
 default-features = false
 
 [dev-dependencies]
-hex-literal = "0.3.1"
 assert_matches = "1.5.0"
+etk-asm = { path = "../etk-asm", version = "0.2.0-dev" }
+hex-literal = "0.3.1"
 
 [[bin]]
 name = "ecfg"


### PR DESCRIPTION
`cargo test` fails otherwise. Probably my fault for not checking in #76. Maybe it makes sense to have `cargo test` run in the CI somewhere rather than just `cargo test --all --all-features`?