### PR TITLE
Replace into_keys with into_iter/map

### DIFF
--- a/etk-asm/src/asm.rs
+++ b/etk-asm/src/asm.rs
@@ -266,7 +266,8 @@ impl Assembler {
                             ..
                         }) => {
                             let labels = op.expr().unwrap().labels(&self.declared_macros).unwrap();
-                            let declared: HashSet<_> = self.declared_labels.into_keys().collect();
+                            let declared: HashSet<_> =
+                                self.declared_labels.into_iter().map(|(k, _)| k).collect();
                             let invoked: HashSet<_> = labels.into_iter().collect();
                             let missing = invoked
                                 .difference(&declared)


### PR DESCRIPTION
Improves compatibility with older rust versions.