### PR TITLE
Parse push macro within instruction macro defn

### DIFF
--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -35,11 +35,11 @@ half_word_size = @{ ("1" ~ '0'..'6') | '1'..'9' }
 // instruction macros //
 ////////////////////////
 instruction_macro_definition = { "%macro" ~ function_declaration ~ NEWLINE* ~ (instruction_macro_stmt ~ NEWLINE)* ~ "%end" }
-instruction_macro_stmt = _{ label_definition | builtin | instruction_macro | push | op }
+instruction_macro_stmt = _{ label_definition | "%" ~ push_macro | local_macro | push | op }
 instruction_macro_variable = @{ "$" ~ function_parameter }
 instruction_macro = !{ "%" ~ function_invocation }
 
-local_macro = { instruction_macro_definition | instruction_macro  | expression_macro_definition }
+local_macro = { !builtin ~ (instruction_macro_definition | instruction_macro  | expression_macro_definition) }
 builtin = ${ "%" ~ ( import | include | include_hex | push_macro ) }
 
 import = !{ "import" ~ arguments }

--- a/etk-asm/src/parse/macros.rs
+++ b/etk-asm/src/parse/macros.rs
@@ -64,7 +64,12 @@ fn parse_instruction_macro_defn(pair: Pair<Rule>) -> Result<AbstractOp, ParseErr
 
     let mut contents = Vec::<AbstractOp>::new();
     for pair in pairs {
-        contents.push(super::parse_abstract_op(pair)?);
+        if pair.as_rule() == Rule::push_macro {
+            let expr = expression::parse(pair.into_inner().next().unwrap())?;
+            contents.push(AbstractOp::Push(expr.into()));
+        } else {
+            contents.push(super::parse_abstract_op(pair)?);
+        }
     }
 
     let defn = InstructionMacroDefinition {

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -447,6 +447,8 @@ mod tests {
                 gasprice
                 pop
                 push1 $foo + $bar
+                %push(0x42)
+                %another_macro()
             %end
             %my_macro(0x42, 10)
             "#,
@@ -466,6 +468,11 @@ mod tests {
                             )
                             .into()
                         )),
+                        AbstractOp::Push(0x42.into()),
+                        AbstractOp::Macro(InstructionMacroInvocation {
+                            name: "another_macro".into(),
+                            parameters: vec![]
+                        })
                     ]
                 }
                 .into()


### PR DESCRIPTION
Fixes https://github.com/quilt/etk/issues/88.

Also rejects other builtin macros for now.