### PR TITLE
fixed a typo in the doc comment for Expression enum

### DIFF
--- a/etk-asm/src/ops/expression.rs
+++ b/etk-asm/src/ops/expression.rs
@@ -90,7 +90,7 @@ impl<'a> From<(&'a LabelsMap, &'a MacrosMap, &'a VariablesMap)> for Context<'a> 
     }
 }
 
-/// An mathematical expression.
+/// A mathematical expression.
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Expression {
     /// A mathematical expression.


### PR DESCRIPTION
Fixed a small typo

```diff
-/// An mathematical expression.
+/// A mathematical expression.
```