### PR TITLE
allowing empty lines for instruction macros.

### DIFF
--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -34,7 +34,7 @@ half_word_size = @{ ("1" ~ '0'..'6') | '1'..'9' }
 ////////////////////////
 // instruction macros //
 ////////////////////////
-instruction_macro_definition = { "%macro" ~ function_declaration ~ NEWLINE* ~ (instruction_macro_stmt ~ NEWLINE)* ~ "%end" }
+instruction_macro_definition = { "%macro" ~ function_declaration ~ NEWLINE* ~ (instruction_macro_stmt ~ NEWLINE*)* ~ "%end" }
 instruction_macro_stmt = _{ label_definition | "%" ~ push_macro | local_macro | push | op }
 instruction_macro_variable = @{ "$" ~ function_parameter }
 instruction_macro = !{ "%" ~ function_invocation }

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -34,7 +34,7 @@ half_word_size = @{ ("1" ~ '0'..'6') | '1'..'9' }
 ////////////////////////
 // instruction macros //
 ////////////////////////
-instruction_macro_definition = { "%macro" ~ function_declaration ~ NEWLINE* ~ (instruction_macro_stmt ~ NEWLINE*)* ~ "%end" }
+instruction_macro_definition = { "%macro" ~ function_declaration ~ NEWLINE* ~ (instruction_macro_stmt ~ NEWLINE+)* ~ "%end" }
 instruction_macro_stmt = _{ label_definition | "%" ~ push_macro | local_macro | push | op }
 instruction_macro_variable = @{ "$" ~ function_parameter }
 instruction_macro = !{ "%" ~ function_invocation }

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -89,12 +89,23 @@ fn instruction_macro_with_empty_lines() -> Result<(), Error> {
     let mut ingester = Ingest::new(&mut output);
     ingester.ingest_file(source(&["instruction-macro", "empty_lines.etk"]))?;
 
-    assert_eq!(
-        output,
-        hex!("6000600060006000600060006000")
-    );
+    assert_eq!(output, hex!("6000600060006000600060006000"));
 
     Ok(())
+}
+
+#[test]
+fn instruction_macro_with_two_instructions_per_line() {
+    let mut output = Vec::new();
+    let mut ingester = Ingest::new(&mut output);
+    let err = ingester
+        .ingest_file(source(&[
+            "instruction-macro",
+            "macro-with-2-instructions-per-line.etk",
+        ]))
+        .unwrap_err();
+
+    assert_matches!(err, Error::Parse { .. });
 }
 
 #[test]

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -84,6 +84,20 @@ fn instruction_macro() -> Result<(), Error> {
 }
 
 #[test]
+fn instruction_macro_with_empty_lines() -> Result<(), Error> {
+    let mut output = Vec::new();
+    let mut ingester = Ingest::new(&mut output);
+    ingester.ingest_file(source(&["instruction-macro", "empty_lines.etk"]))?;
+
+    assert_eq!(
+        output,
+        hex!("6000600060006000600060006000")
+    );
+
+    Ok(())
+}
+
+#[test]
 fn every_op() -> Result<(), Error> {
     let mut output = Vec::new();
     let mut ingester = Ingest::new(&mut output);

--- a/etk-asm/tests/asm/instruction-macro/empty_lines.etk
+++ b/etk-asm/tests/asm/instruction-macro/empty_lines.etk
@@ -1,0 +1,42 @@
+%macro foo1()
+	push1 0
+
+	push1 0
+%end
+
+%macro foo2()
+
+	push1 0
+%end
+
+%macro foo3()
+	push1 0
+
+%end
+
+%macro foo4()
+
+	push1 0
+
+%end
+
+%macro foo5()
+
+
+
+
+
+
+	push1 0
+
+
+
+    push1 0
+
+%end
+
+%foo1()
+%foo2()
+%foo3()
+%foo4()
+%foo5()

--- a/etk-asm/tests/asm/instruction-macro/macro-with-2-instructions-per-line.etk
+++ b/etk-asm/tests/asm/instruction-macro/macro-with-2-instructions-per-line.etk
@@ -1,0 +1,4 @@
+%macro foo()
+    push1 0 chainid
+%end
+%foo()


### PR DESCRIPTION
According to the old pest grammar for instruction macros:

```pest
instruction_macro_definition = { 
    "%macro" ~ function_declaration ~ NEWLINE* ~ 
        (instruction_macro_stmt ~ NEWLINE)* ~ 
    "%end"
}
```

macros like the follwing are allowed:

```asm
%macro foo()
    
    
    push1 0
%end
```

we changed the grammar to allow empty lines after and in between `instruction_macro_stmt`'s. So that the following macros would also be well-defined:

```asm
%macro foo()
    
    
    push1 0

    chainid



%end
```

It would make the `.etk` code more readable.

Grammar change:

```diff
- ... (instruction_macro_stmt ~ NEWLINE)* ...
+ ... (instruction_macro_stmt ~ NEWLINE*)* ...
```

A test for this feature has also been added: `instruction_macro_with_empty_lines`