### PR TITLE
Allow hex strings without 0x prefix

### DIFF
--- a/etk-cli/src/parse.rs
+++ b/etk-cli/src/parse.rs
@@ -50,7 +50,11 @@ where
     type Err = FromHexError<<T as FromHex>::Error>;
 
     fn from_str(txt: &str) -> Result<Self, Self::Err> {
-        let rest = txt.strip_prefix("0x").ok_or(FromHexError::Prefix)?;
+        let rest = if txt.starts_with("0x") {
+            txt.strip_prefix("0x").unwrap()
+        } else {
+            txt
+        };
         let item = T::from_hex(rest).map_err(FromHexError::Hex)?;
         Ok(Self(item))
     }


### PR DESCRIPTION
## Motivation

The "0x" prefix solves the ambiguity for the string "11", which could represent eleven or seventeen. Hence, it makes sense to include  "0x" prefix everywhere in general.

However, a lot of popular tools in the ecosystem omit "0x" prefix. E.g. Bytecode from Remix, Hardhat, Solc compiler, evm.codes playground. And this does not create any ambiguity at all, since bytecode is supposed to be in hex format. Etk cli does not accept bytecode in a different format. Hence, flexibility can be provided to accept a hex string with or without "0x" prefix, for improving the convenience of the dev/user.

A related case: ethers.js is quiet strict with requirement of "0x" prefix, but the requirement of the prefix for private keys was made optional, because a lot of common tools do not prefix private keys with a 0x https://github.com/ethers-io/ethers.js/commit/29f6c34343d75fa42023bdcd07632f49a450570c

Before:

```sh
disease --code 60026001b46001b360005260206000F3 
error: Invalid value for '--code <code>': missing 0x prefix
```

After

```sh
disease --code 60026001b46001b360005260206000F3 
// works
```
