### PR TITLE
fix(eas): allow `path/to/output` & add clean-up

### DIFF
--- a/etk-asm/src/bin/eas.rs
+++ b/etk-asm/src/bin/eas.rs
@@ -51,7 +51,7 @@ fn run() -> Result<(), Error> {
             match std::fs::read(o) {
                 Ok(content) => out_file_content = content,
                 Err(e) => panic!("couldn't backup existing file: {}", e),
-            }            
+            }
         }
     }
 


### PR DESCRIPTION
Gm! ETK is an amazing toolkit and I wanted to contribute.

This is my fist time working with Rust - feel free to make any changes and merge/close the PR, because I'll be AFK.

## Motivation

1. `eas` errors if a directory on the path to the output file doesn't exist.
2. An empty output file is created if `eas` fails. In case of an existing file, that one will be overwritten.

## Solution

1. Create any directories specified on the path to the output file that don't exist.
2. Do not create an output file or overwrite the existing file if `eas` fails.

Thanks!