### PR TITLE
all: start v0.4 release cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "etk-4byte"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "bincode",
  "brotli",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "etk-analyze"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "assert_matches",
  "clap 3.1.18",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "etk-asm"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "assert_matches",
  "clap 3.1.18",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "etk-cli"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "clap 3.1.18",
  "hex",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "etk-dasm"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "clap 3.1.18",
  "etk-4byte",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "etk-ops"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "educe",
  "indexmap",

--- a/etk-4byte/Cargo.toml
+++ b/etk-4byte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etk-4byte"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["Sam Wilson <sam.wilson@mesh.xyz>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/etk-analyze/Cargo.toml
+++ b/etk-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etk-analyze"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2018"
 authors = ["Sam Wilson <sam.wilson@mesh.xyz>", "lightclient <lightclient@protonmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -17,9 +17,9 @@ cli = ["etk-cli", "etk-asm", "clap", "snafu"]
 [dependencies]
 snafu = { optional = true, version = "0.7.1" }
 clap = { optional = true, version = "3.1", features = ["derive"] }
-etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0" }
-etk-asm = { optional = true, path = "../etk-asm", version = "0.3.0" }
-etk-dasm = { path = "../etk-dasm", version = "0.3.0" }
+etk-cli = { optional = true, path = "../etk-cli", version = "0.4.0-dev" }
+etk-asm = { optional = true, path = "../etk-asm", version = "0.4.0-dev" }
+etk-dasm = { path = "../etk-dasm", version = "0.4.0-dev" }
 z3 = { version = "0.11.2", features = ["static-link-z3"] }
 
 [dependencies.petgraph]
@@ -28,7 +28,7 @@ default-features = false
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-etk-asm = { path = "../etk-asm", version = "0.3.0" }
+etk-asm = { path = "../etk-asm", version = "0.4.0-dev" }
 hex-literal = "0.3.4"
 
 [[bin]]

--- a/etk-asm/Cargo.toml
+++ b/etk-asm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etk-asm"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["Sam Wilson <sam.wilson@mesh.xyz>", "lightclient <lightclient@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -16,8 +16,8 @@ cli = ["clap", "etk-cli"]
 backtraces = [ "snafu/backtraces", "etk-ops/backtraces" ]
 
 [dependencies]
-etk-ops = { path = "../etk-ops", version = "0.3.0" }
-etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0" }
+etk-ops = { path = "../etk-ops", version = "0.4.0-dev" }
+etk-cli = { optional = true, path = "../etk-cli", version = "0.4.0-dev" }
 hex = "0.4.3"
 num-bigint = "0.4"
 pest = "2.1.3"

--- a/etk-cli/Cargo.toml
+++ b/etk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etk-cli"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["Sam Wilson <sam.wilson@mesh.xyz>", "lightclient <lightclient@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/etk-dasm/Cargo.toml
+++ b/etk-dasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etk-dasm"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["Sam Wilson <sam.wilson@mesh.xyz>", "lightclient <lightclient@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -16,11 +16,11 @@ cli = ["clap", "etk-cli", "snafu", "etk-4byte"]
 
 [dependencies]
 hex = "0.4.3"
-etk-ops = { path = "../etk-ops", version = "0.3.0" }
-etk-asm = { path = "../etk-asm", version = "0.3.0" }
+etk-ops = { path = "../etk-ops", version = "0.4.0-dev" }
+etk-asm = { path = "../etk-asm", version = "0.4.0-dev" }
 clap = { optional = true, version = "3.1", features = ["derive"] }
-etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0" }
-etk-4byte = { optional = true, path = "../etk-4byte", version = "0.3.0" }
+etk-cli = { optional = true, path = "../etk-cli", version = "0.4.0-dev" }
+etk-4byte = { optional = true, path = "../etk-4byte", version = "0.4.0-dev" }
 snafu = { optional = true, version = "0.7.1" }
 
 [dev-dependencies]

--- a/etk-ops/Cargo.toml
+++ b/etk-ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etk-ops"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["Sam Wilson <sam.wilson@mesh.xyz>", "lightclient <lightclient@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This moves all cargo.toml versions to `v0.4.0-dev`.