### PR TITLE
all: use v0.3

### DIFF
--- a/etk-analyze/Cargo.toml
+++ b/etk-analyze/Cargo.toml
@@ -17,9 +17,9 @@ cli = ["etk-cli", "etk-asm", "clap", "snafu"]
 [dependencies]
 snafu = { optional = true, version = "0.7.1" }
 clap = { optional = true, version = "3.1", features = ["derive"] }
-etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0-dev" }
-etk-asm = { optional = true, path = "../etk-asm", version = "0.3.0-dev" }
-etk-dasm = { path = "../etk-dasm", version = "0.3.0-dev" }
+etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0" }
+etk-asm = { optional = true, path = "../etk-asm", version = "0.3.0" }
+etk-dasm = { path = "../etk-dasm", version = "0.3.0" }
 z3 = { version = "0.11.2", features = ["static-link-z3"] }
 
 [dependencies.petgraph]
@@ -28,7 +28,7 @@ default-features = false
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-etk-asm = { path = "../etk-asm", version = "0.3.0-dev" }
+etk-asm = { path = "../etk-asm", version = "0.3.0" }
 hex-literal = "0.3.4"
 
 [[bin]]

--- a/etk-asm/Cargo.toml
+++ b/etk-asm/Cargo.toml
@@ -16,8 +16,8 @@ cli = ["clap", "etk-cli"]
 backtraces = [ "snafu/backtraces", "etk-ops/backtraces" ]
 
 [dependencies]
-etk-ops = { path = "../etk-ops", version = "0.3.0-dev" }
-etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0-dev" }
+etk-ops = { path = "../etk-ops", version = "0.3.0" }
+etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0" }
 hex = "0.4.3"
 num-bigint = "0.4"
 pest = "2.1.3"

--- a/etk-dasm/Cargo.toml
+++ b/etk-dasm/Cargo.toml
@@ -16,11 +16,11 @@ cli = ["clap", "etk-cli", "snafu", "etk-4byte"]
 
 [dependencies]
 hex = "0.4.3"
-etk-ops = { path = "../etk-ops", version = "0.3.0-dev" }
-etk-asm = { path = "../etk-asm", version = "0.3.0-dev" }
+etk-ops = { path = "../etk-ops", version = "0.3.0" }
+etk-asm = { path = "../etk-asm", version = "0.3.0" }
 clap = { optional = true, version = "3.1", features = ["derive"] }
-etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0-dev" }
-etk-4byte = { optional = true, path = "../etk-4byte", version = "0.3.0-dev" }
+etk-cli = { optional = true, path = "../etk-cli", version = "0.3.0" }
+etk-4byte = { optional = true, path = "../etk-4byte", version = "0.3.0" }
 snafu = { optional = true, version = "0.7.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
Need to update local uses to `v0.3.0`.