### PR TITLE
Assembler simplification

### DIFF
--- a/etk-asm/src/asm.rs
+++ b/etk-asm/src/asm.rs
@@ -283,12 +283,18 @@ impl Assembler {
     /// Concretize ops given calculated labels
     pub fn finish(&mut self) -> Result<(), Error> {
         for op in self.unrolled.iter() {
-            if let RawOp::Op(ref aop) = op {
-                let cop = aop
-                    .clone()
-                    .concretize((&self.declared_labels, &self.declared_macros).into());
+            match op {
+                RawOp::Op(AbstractOp::Label(_)) => continue,
+                RawOp::Op(AbstractOp::MacroDefinition(_)) => continue,
+                RawOp::Op(aop) => {
+                    let cop = aop
+                        .clone()
+                        .concretize((&self.declared_labels, &self.declared_macros).into());
 
-                cop.unwrap().assemble(&mut self.ready);
+                    // TODO cop can be an error, handle it
+                    cop.assemble(&mut self.ready);
+                }
+                RawOp::Raw(_) => continue,
             }
         }
         Ok(())

--- a/etk-asm/src/ingest.rs
+++ b/etk-asm/src/ingest.rs
@@ -298,7 +298,7 @@ where
         };
 
         let raw = asm.take();
-        asm.finish()?;
+        //asm.finish()?;
 
         if raw.is_empty() {
             return Ok(());
@@ -350,6 +350,7 @@ where
 
         let source_zero = &mut self.sources[0];
 
+        // change to explore all sources?
         let first_asm = match &mut source_zero.scope {
             Scope::Independent(ref mut a) => a,
             Scope::Same => panic!("sources[0] must be independent"),
@@ -357,7 +358,7 @@ where
 
         source_zero
             .nodes
-            .by_ref()
+            .clone()
             .filter(|node| {
                 matches!(
                     node,

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -276,3 +276,12 @@ fn every_op() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn test_ass() -> Result<(), Error> {
+    let mut output = Vec::new();
+    let mut ingester = Ingest::new(&mut output);
+    ingester.ingest_file(source(&["every-op", "test.etk"]))?;
+
+    Ok(())
+}


### PR DESCRIPTION
This is a WIP of the assembler simplification.
The main idea is to drop the use of the pending vector that accumulates bytecodes until the definition of a label is reached.

There is still a lot to optimise, but the general idea is as follows:
- Scan the code to identify labels and macros (surely this can be removed).
- Process the code in its entirety, expanding macros where possible and saving label positions as they appear.
- A final pass to concretise all the labels, assigning them their corresponding value.

As I said before, this is still a work in progress, as I don't think it's necessary to do three passes through the code.