### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # EVM Toolkit (`etk`)
 
 [![license](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](https://github.com/quilt/etk)


### PR DESCRIPTION
%push(addr) -> replaced by the smallest push opcode that can represent addr.
 %jump(addr) -> replaced by a push (as %push(addr)) and a jump opcode.
These macros are somewhat difficult because the size of label depends on the instructions preceding it.