### PR TITLE
EOF container assembler prototype

### DIFF
--- a/etk-asm/src/ops.rs
+++ b/etk-asm/src/ops.rs
@@ -170,6 +170,10 @@ impl Access {
 pub enum EOFSectionKind {
     /// Code section
     Code {
+        /// Code section's inputs
+        inputs: u8,
+        /// Code section's outputs or 0x80 if secton is non-returning
+        outputs: u8,
         /// Code section's max stack height
         max_stack_height: u16,
     },

--- a/etk-asm/src/ops.rs
+++ b/etk-asm/src/ops.rs
@@ -165,6 +165,15 @@ impl Access {
     }
 }
 
+/// Kind of EOF section
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EOFSectionKind {
+    /// Code section
+    Code,
+    /// Data section
+    Data,
+}
+
 /// Like an [`Op`], except it also supports virtual instructions.
 ///
 /// In addition to the real EVM instructions, `AbstractOp` also supports defining
@@ -187,7 +196,7 @@ pub enum AbstractOp {
     Macro(InstructionMacroInvocation),
 
     /// EOF Section
-    EOFSection,
+    EOFSection(EOFSectionKind),
 }
 
 impl AbstractOp {
@@ -235,7 +244,7 @@ impl AbstractOp {
             Self::Label(_) => panic!("labels cannot be concretized"),
             Self::Macro(_) => panic!("macros cannot be concretized"),
             Self::MacroDefinition(_) => panic!("macro definitions cannot be concretized"),
-            Self::EOFSection => panic!("EOF sections cannot be concretized"),
+            Self::EOFSection(_) => panic!("EOF sections cannot be concretized"),
         }
     }
 
@@ -269,7 +278,7 @@ impl AbstractOp {
             Self::Push(_) => None,
             Self::Macro(_) => None,
             Self::MacroDefinition(_) => None,
-            Self::EOFSection => None,
+            Self::EOFSection(_) => None,
         }
     }
 
@@ -305,6 +314,20 @@ impl From<ExpressionMacroDefinition> for AbstractOp {
     }
 }
 
+impl fmt::Display for EOFSectionKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Code => {
+                write!(f, "code")?;
+            }
+            Self::Data => {
+                write!(f, "data")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for AbstractOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -319,7 +342,7 @@ impl fmt::Display for AbstractOp {
             Self::Label(lbl) => write!(f, r#"{}:"#, lbl),
             Self::Macro(m) => write!(f, "{}", m),
             Self::MacroDefinition(defn) => write!(f, "{}", defn),
-            Self::EOFSection => write!(f, "EOF section"),
+            Self::EOFSection(kind) => write!(f, "EOF {} section", kind),
         }
     }
 }

--- a/etk-asm/src/ops.rs
+++ b/etk-asm/src/ops.rs
@@ -185,6 +185,9 @@ pub enum AbstractOp {
 
     /// A user-defined macro, which is a virtual instruction.
     Macro(InstructionMacroInvocation),
+
+    /// EOF Section
+    EOFSection,
 }
 
 impl AbstractOp {
@@ -232,6 +235,7 @@ impl AbstractOp {
             Self::Label(_) => panic!("labels cannot be concretized"),
             Self::Macro(_) => panic!("macros cannot be concretized"),
             Self::MacroDefinition(_) => panic!("macro definitions cannot be concretized"),
+            Self::EOFSection => panic!("EOF sections cannot be concretized"),
         }
     }
 
@@ -265,6 +269,7 @@ impl AbstractOp {
             Self::Push(_) => None,
             Self::Macro(_) => None,
             Self::MacroDefinition(_) => None,
+            Self::EOFSection => None,
         }
     }
 
@@ -314,6 +319,7 @@ impl fmt::Display for AbstractOp {
             Self::Label(lbl) => write!(f, r#"{}:"#, lbl),
             Self::Macro(m) => write!(f, "{}", m),
             Self::MacroDefinition(defn) => write!(f, "{}", defn),
+            Self::EOFSection => write!(f, "EOF section"),
         }
     }
 }

--- a/etk-asm/src/ops.rs
+++ b/etk-asm/src/ops.rs
@@ -169,7 +169,10 @@ impl Access {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EOFSectionKind {
     /// Code section
-    Code,
+    Code {
+        /// Code section's max stack height
+        max_stack_height: u16,
+    },
     /// Data section
     Data,
 }
@@ -317,7 +320,7 @@ impl From<ExpressionMacroDefinition> for AbstractOp {
 impl fmt::Display for EOFSectionKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Code => {
+            Self::Code { .. } => {
                 write!(f, "code")?;
             }
             Self::Data => {

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -3,7 +3,7 @@
 ///////////////////////
 program = _{ SOI ~ inner ~ EOI }
 inner = _{ NEWLINE* ~ (stmt ~ (NEWLINE+|";"))* ~ stmt? }
-stmt = _{ label_definition | builtin | local_macro | push | op }
+stmt = _{ label_definition | builtin | local_macro | push | op  | section }
 
 //////////////////////
 // opcode mnemonics //
@@ -67,6 +67,12 @@ function_declaration = { function_name ~ "(" ~ function_parameter* ~ ("," ~ func
 function_invocation = _{ function_name ~ "(" ~ expression* ~ ("," ~ expression)* ~ ")" }
 function_name = @{ ( ASCII_ALPHA | "_" ) ~ ( ASCII_ALPHANUMERIC | "_" )* }
 function_parameter = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
+
+//////////////
+// sections //
+//////////////
+section = @{ "section" ~ WHITESPACE ~ section_kind }
+section_kind = { (".code" | ".data") }
 
 //////////////
 // operands //

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -71,8 +71,10 @@ function_parameter = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
 //////////////
 // sections //
 //////////////
-section = ${ "section" ~ WHITESPACE ~ section_kind }
+section = ${ "section" ~ WHITESPACE ~ section_kind ~ (WHITESPACE ~ section_attributes)? }
 section_kind = { ".code" | ".data" }
+section_attributes = { max_stack_height_attribute? }
+max_stack_height_attribute = { "max_stack_height" ~ "=" ~ number }
 
 //////////////
 // operands //

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -73,8 +73,12 @@ function_parameter = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
 //////////////
 section = ${ "section" ~ WHITESPACE ~ section_kind ~ (WHITESPACE ~ section_attributes)? }
 section_kind = { ".code" | ".data" }
-section_attributes = { max_stack_height_attribute? }
+section_attributes = { (section_attribute ~WHITESPACE?)* }
+section_attribute = { inputs_attribute | outputs_attribute | max_stack_height_attribute }
 max_stack_height_attribute = { "max_stack_height" ~ "=" ~ number }
+inputs_attribute = { "inputs" ~ "=" ~ number }
+outputs_attribute = { "outputs" ~ "=" ~ (number | nonreturning) }
+nonreturning = { "nonret" }
 
 //////////////
 // operands //

--- a/etk-asm/src/parse/asm.pest
+++ b/etk-asm/src/parse/asm.pest
@@ -71,8 +71,8 @@ function_parameter = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
 //////////////
 // sections //
 //////////////
-section = @{ "section" ~ WHITESPACE ~ section_kind }
-section_kind = { (".code" | ".data") }
+section = ${ "section" ~ WHITESPACE ~ section_kind }
+section_kind = { ".code" | ".data" }
 
 //////////////
 // operands //

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -21,7 +21,7 @@ use self::{
 };
 
 use crate::ast::Node;
-use crate::ops::AbstractOp;
+use crate::ops::{AbstractOp, EOFSectionKind};
 use etk_ops::cancun::Op;
 use num_bigint::BigInt;
 use pest::{iterators::Pair, Parser};
@@ -55,8 +55,14 @@ fn parse_abstract_op(pair: Pair<Rule>) -> Result<AbstractOp, ParseError> {
             AbstractOp::Op(op)
         }
         Rule::section => {
-            // TODO get section kind
-            AbstractOp::EOFSection
+            let mut pair = pair.into_inner();
+            let section_kind = pair.next().unwrap().as_str();
+
+            if section_kind == ".code" {
+                AbstractOp::EOFSection(EOFSectionKind::Code)
+            } else {
+                AbstractOp::EOFSection(EOFSectionKind::Data)
+            }
         }
         _ => unreachable!(),
     };

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -55,12 +55,30 @@ fn parse_abstract_op(pair: Pair<Rule>) -> Result<AbstractOp, ParseError> {
             AbstractOp::Op(op)
         }
         Rule::section => {
-            let mut pair = pair.into_inner();
-            let section_kind = pair.next().unwrap().as_str();
+            let mut pairs = pair.into_inner();
+            let section_kind = pairs.next().unwrap().as_str();
 
             if section_kind == ".code" {
-                AbstractOp::EOFSection(EOFSectionKind::Code)
+                let max_stack_height = {
+                    if let Some(section_attributes) = pairs.next() {
+                        if let Some(msh_pair) = section_attributes.into_inner().next() {
+                            msh_pair
+                                .into_inner()
+                                .next()
+                                .unwrap()
+                                .as_str()
+                                .parse::<u16>()
+                                .unwrap()
+                        } else {
+                            0
+                        }
+                    } else {
+                        0
+                    }
+                };
+                AbstractOp::EOFSection(EOFSectionKind::Code { max_stack_height })
             } else {
+                // attributes are ignored
                 AbstractOp::EOFSection(EOFSectionKind::Data)
             }
         }

--- a/etk-asm/src/parse/mod.rs
+++ b/etk-asm/src/parse/mod.rs
@@ -54,6 +54,10 @@ fn parse_abstract_op(pair: Pair<Rule>) -> Result<AbstractOp, ParseError> {
             let op = Op::new(spec).unwrap();
             AbstractOp::Op(op)
         }
+        Rule::section => {
+            // TODO get section kind
+            AbstractOp::EOFSection
+        }
         _ => unreachable!(),
     };
 

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -348,3 +348,14 @@ fn test_include_hex() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn test_eof_minimal() -> Result<(), Error> {
+    let mut output = Vec::new();
+    let mut ingester = Ingest::new(&mut output);
+    ingester.ingest_file(source(&["eof", "main1.etk"]))?;
+
+    assert_eq!(output, hex!("ef00010100040200010001040000000080000000"));
+
+    Ok(())
+}

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -355,7 +355,24 @@ fn test_eof_minimal() -> Result<(), Error> {
     let mut ingester = Ingest::new(&mut output);
     ingester.ingest_file(source(&["eof", "main1.etk"]))?;
 
-    assert_eq!(output, hex!("ef00010100040200010001040000000080000000"));
+    assert_eq!(
+        output,
+        hex!("ef0001 010004 0200010001 040000 00 00800000 00")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_eof_multiple_code_sections() -> Result<(), Error> {
+    let mut output = Vec::new();
+    let mut ingester = Ingest::new(&mut output);
+    ingester.ingest_file(source(&["eof", "main2.etk"]))?;
+
+    assert_eq!(
+        output,
+        hex!("ef0001 01000c 020003000100010003 040000 00 00800000 00800000 00800000 00 fe 5f5ff3")
+    );
 
     Ok(())
 }

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -371,7 +371,7 @@ fn test_eof_multiple_code_sections() -> Result<(), Error> {
 
     assert_eq!(
         output,
-        hex!("ef0001 01000c 020003000100010003 040000 00 00800000 00800000 00800000 00 fe 5f5ff3")
+        hex!("ef0001 01000c 020003000100010003 040000 00 00800000 00800000 00800002 00 fe 5f5ff3")
     );
 
     Ok(())
@@ -383,7 +383,7 @@ fn test_eof_data_section() -> Result<(), Error> {
     let mut ingester = Ingest::new(&mut output);
     ingester.ingest_file(source(&["eof", "main3.etk"]))?;
 
-    assert_eq!(output, hex!("ef0001 01000c 020003000100010003 040004 00 00800000 00800000 00800000 00 fe 5f5ff3 cafeb0ba"));
+    assert_eq!(output, hex!("ef0001 01000c 020003000100010003 040004 00 00800000 00800000 00800002 00 fe 5f5ff3 cafeb0ba"));
 
     Ok(())
 }

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -376,3 +376,14 @@ fn test_eof_multiple_code_sections() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn test_eof_data_section() -> Result<(), Error> {
+    let mut output = Vec::new();
+    let mut ingester = Ingest::new(&mut output);
+    ingester.ingest_file(source(&["eof", "main3.etk"]))?;
+
+    assert_eq!(output, hex!("ef0001 01000c 020003000100010003 040004 00 00800000 00800000 00800000 00 fe 5f5ff3 cafeb0ba"));
+
+    Ok(())
+}

--- a/etk-asm/tests/asm.rs
+++ b/etk-asm/tests/asm.rs
@@ -369,10 +369,7 @@ fn test_eof_multiple_code_sections() -> Result<(), Error> {
     let mut ingester = Ingest::new(&mut output);
     ingester.ingest_file(source(&["eof", "main2.etk"]))?;
 
-    assert_eq!(
-        output,
-        hex!("ef0001 01000c 020003000100010003 040000 00 00800000 00800000 00800002 00 fe 5f5ff3")
-    );
+    assert_eq!(output, hex!("ef0001 010010 0200040001000100030004 040000 00 00800000 00800000 00800002 01000002 00 fe 5f5ff3 505f5f00"));
 
     Ok(())
 }

--- a/etk-asm/tests/asm/eof/data.etk
+++ b/etk-asm/tests/asm/eof/data.etk
@@ -1,0 +1,1 @@
+cafeb0ba

--- a/etk-asm/tests/asm/eof/main1.etk
+++ b/etk-asm/tests/asm/eof/main1.etk
@@ -1,0 +1,2 @@
+section .code
+stop

--- a/etk-asm/tests/asm/eof/main2.etk
+++ b/etk-asm/tests/asm/eof/main2.etk
@@ -1,0 +1,10 @@
+section .code
+stop
+
+section .code
+invalid
+
+section .code
+push0
+push0
+return

--- a/etk-asm/tests/asm/eof/main2.etk
+++ b/etk-asm/tests/asm/eof/main2.etk
@@ -4,7 +4,7 @@ stop
 section .code
 invalid
 
-section .code
+section .code max_stack_height=2
 push0
 push0
 return

--- a/etk-asm/tests/asm/eof/main2.etk
+++ b/etk-asm/tests/asm/eof/main2.etk
@@ -1,10 +1,16 @@
 section .code
 stop
 
-section .code
+section .code outputs=nonret
 invalid
 
-section .code max_stack_height=2
+section .code outputs=nonret max_stack_height=2
 push0
 push0
 return
+
+section .code inputs=1 outputs=0 max_stack_height=2
+pop
+push0
+push0
+stop

--- a/etk-asm/tests/asm/eof/main3.etk
+++ b/etk-asm/tests/asm/eof/main3.etk
@@ -1,0 +1,13 @@
+section .code
+stop
+
+section .code
+invalid
+
+section .code
+push0
+push0
+return
+
+section .data
+%include_hex("data.etk")

--- a/etk-asm/tests/asm/eof/main3.etk
+++ b/etk-asm/tests/asm/eof/main3.etk
@@ -4,7 +4,7 @@ stop
 section .code
 invalid
 
-section .code
+section .code max_stack_height=2
 push0
 push0
 return


### PR DESCRIPTION
This is a prototype for emitting EOF container bytecode from assembler.

The following syntax for defining EOF sections is proposed:
```asm
section .code
stop

section .code outputs=1
push0
retf

section .code inputs=1 outputs=nonret max_stack_height=2
pop
push0
push0
return

section .data
%include_hex("data.etk")
```

- EOF container is generated in case at least one section is defined, otherwise legacy code is generated.
- Code sections and data section are supported.
- Code sections may declare their number of inputs/outputs and max stack height (this data goes into EOF type section)
- Section attributes are optional and by default are `inputs=0  outputs=nonret max_stack_height=0`
- `outputs=nonret` means sections is non-returning.

### TODO
- [ ] Each code section should be in a separate scope
- [ ] Test that sections get correct size when variable-size pushes are used
- [ ] `max_stack_height` may be automatically calculated within a forward pass during assembly

### Known issues / limitations:
- Attributes are allowed for data sections too, but are ignored (probably shoud be disallowed)
- Attributes can be duplicated, only last mentioned value is used (better should not be allowed)
- No bounds checking for attribute values, panic when above the limit

### Future work for EOF support
- Support new instructions (partially done in #128, #129, #130, #131)
- Support nested containers (for this we'll probably need a directive for defining section end besides section start)
- Disallow banned instruction in EOF? e.g. dynamic jumps
- General question whether etk should allow generating invalid code, or should it be validated
- Support in disassembler?